### PR TITLE
Add gpio driver

### DIFF
--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -3,18 +3,26 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt::gpio::{Level, Output, OutputDrive};
+use embassy_imxrt::gpio::{Port, Level, Output, OutputDrive};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     info!("started running");
     let p = embassy_imxrt::init(Default::default());
 
+    Port::init(Port::Port0); // to enable GPIO port 0
     let mut led = Output::new(p.PIO0_26, Level::Low, OutputDrive::Normal);
 
+    let mut cnt =0;
     loop {
         info!("Toggling GPIO");
         led.toggle();
         embassy_imxrt_examples::delay(50_000);
+        cnt+=1;
+        if cnt==20{
+            break;
+        }
     }
+    led.set_as_disconnected();
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,6 @@ pub fn init(config: config::Config) -> Peripherals {
         #[cfg(feature = "time-driver")]
         time_driver::init(config.time_interrupt_priority);
         // dma::init();
-        gpio::init();
     }
 
     peripherals


### PR DESCRIPTION
This is the commit for gpio - output and input driver
 
Right now, I have only supported for
Output:  Port0,Pin26... `impl_pin!(pio0_26, 0 , 26)`;
Input: Port0, Pin10 `impl_pin!(pio0_10, 0 , 10)`; in gpio.rs, lib.rs file. 
Other pins can be added in similar fashion. Once, review is done, I'll add more.