### PR TITLE
Fix cargo doc warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![no-std](https://github.com/pop-project/embassy-imxrt/actions/workflows/nostd.yml/badge.svg)](https://github.com/pop-project/embassy-imxrt/actions/workflows/nostd.yml)
 [![check](https://github.com/pop-project/embassy-imxrt/actions/workflows/check.yml/badge.svg)](https://github.com/pop-project/embassy-imxrt/actions/workflows/check.yml)
-[![LICENSE](https://img.shields.io/badge/License-MIT-blue)](LICENSE)
+[![LICENSE](https://img.shields.io/badge/License-MIT-blue)](./LICENSE)
 
 ## Introduction
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ embassy_hal_internal::interrupt_mod!(
 /// Macro to bind interrupts to handlers.
 ///
 /// This defines the right interrupt handlers, and creates a unit struct (like `struct Irqs;`)
-/// and implements the right [`Binding`]s for it. You can pass this struct to drivers to
+/// and implements the right \[`Binding`\]s for it. You can pass this struct to drivers to
 /// prove at compile-time that the right interrupts have been bound.
 ///
 /// Example of how to bind one interrupt:


### PR DESCRIPTION
This fixes two cargo doc warnings:

One caused by the LICENSE link in the README being interpreted as an intra-doc link, and the other caused by brackets around a term also being interpreted as an intra-doc link.