### PR TITLE
Change VS Code rust-analyzer to use 'clippy'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "editor.formatOnSave": true
     },
     "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.check.command": "clippy",
     "rust-analyzer.cargo.target": "thumbv8m.main-none-eabihf",
     "rust-analyzer.linkedProjects": [
         "${workspaceFolder}/Cargo.toml",


### PR DESCRIPTION
This simple PR updates the VS code settings to ensure `rust-analyzer` will use `cargo clippy` instead of the default `cargo check` during development.