### PR TITLE
Don't allow early cortex-m-rt versions to be used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 nb = "1.0.0"
 cfg-if = "1.0.0"
-cortex-m-rt = ">=0.6.15,<0.8"
+cortex-m-rt = ">=0.7.3,<0.8"
 cortex-m = "0.7.6"
 critical-section = "1.1"
 chrono = { version = "0.4", default-features = false, optional = true }


### PR DESCRIPTION
Due to RUSTSEC-2023-0014, deny usage of old cortex-m-rt versions.

More details:

https://rustsec.org/advisories/RUSTSEC-2023-0014.html