### PR TITLE
Implement I2C Support

### DIFF
--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -1,0 +1,115 @@
+#![no_std]
+#![no_main]
+
+use defmt::{error, info};
+use embassy_executor::Spawner;
+use embassy_imxrt::i2c::{self, I2cMasterBlocking};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // Link to data sheet for accelerometer on the RT685S-EVK
+    // https://www.nxp.com/docs/en/data-sheet/FXOS8700CQ.pdf
+    // Max Freq is 400 kHz
+    // Address is 0x1E, 0x1D, 0x1C or 0x1F
+
+    // Link to schematics for RT685S-EVK
+    // https://www.nxp.com/downloads/en/design-support/RT685-DESIGNFILES.zip
+    // File: SPF-35099_E2.pdf
+    // Page 10 shows ACC Sensor at I2C address 0x1E
+
+    // Link to RT6xx User Manual
+    // https://www.nxp.com/webapp/Download?colCode=UM11147
+
+    // Acc is connected to P0_18_FC2_SCL and P0_17_FC2_SDA for I2C
+    // Acc RESET gpio is P1_7_RST
+    info!("i2c example - embassy_imxrt::init");
+    let p = embassy_imxrt::init(Default::default());
+
+    info!("i2c example - Configure Pins");
+    board_init_pin_clocks();
+
+    info!("i2c example - Configure GPIOs");
+    use embassy_imxrt::gpio::*;
+
+    // Set GPIO1_7 (Reset) as output
+    // Configure IO Pad Control 1_7 for ACC Reset Pin
+    //
+    // Pin is configured as PIO1_7
+    // Disable pull-up / pull-down function
+    // Enable pull-down function
+    // Disable input buffer function
+    // Normal mode
+    // Normal drive
+    // Analog mux is disabled
+    // Pseudo Output Drain is disabled
+    // Input function is not inverted
+    info!("Configuring GPIO1_7 as output");
+    info!("Configuring GPIO1_7 as low");
+    let mut _reset_pin = Output::new(
+        p.PIO1_7,
+        Level::Low,
+        DriveMode::PushPull,
+        DriveStrength::Normal,
+        SlewRate::Standard,
+    );
+
+    // Set GPIO1_5 (Interrupt) as input
+    // Configure IO Pad Control 1_5 for ACC Interrupt Pin
+    //
+    // Pin is configured as PIO1_5
+    // Disable pull-up / pull-down function
+    // Enable pull-down function
+    // Disable input buffer function
+    // Normal mode
+    // Normal drive
+    // Analog mux is disabled
+    // Pseudo Output Drain is disabled
+    // Input function is not inverted
+    info!("Configuring GPIO1_5 as input");
+    let _isr_pin = Input::new(p.PIO1_5.degrade(), Pull::Down, Polarity::ActiveHigh);
+
+    info!("i2c example - I2c::new");
+    let mut i2c = i2c::I2cMaster::new(
+        p.FLEXCOMM2,
+        p.PIO0_18,
+        p.PIO0_17,
+        Pull::Down,
+        i2c::Speed::Standard,
+        i2c::TimeoutSettings {
+            hw_timeout: true,
+            sw_timeout: embassy_time::Duration::from_millis(1000),
+        },
+    )
+    .unwrap();
+
+    // Read WHO_AM_I register, 0x0D to get value 0xC7 (1100 0111)
+    info!("i2c example - ACC WHO_AM_I register check");
+
+    let mut reg = [0u8; 1];
+    reg[0] = 0xAA;
+    let result = i2c.write_read(0x1E, &[0x0D], &mut reg);
+    if result.is_ok() {
+        info!("i2c example - Read WHO_AM_I register: {:02X}", reg[0]);
+    } else {
+        error!("i2c example - Error reading WHO_AM_I register {}", result.unwrap_err());
+    }
+
+    info!("i2c example - Done!  Busy Loop...");
+    loop {
+        embassy_imxrt_examples::delay(50_000_000);
+    }
+}
+
+fn board_init_pin_clocks() {
+    let pac = embassy_imxrt::pac::Peripherals::take().unwrap();
+
+    // Ensure SFRO Clock is set to run (power down is cleared)
+    pac.sysctl0.pdruncfg0_clr().write(|w| w.sfro_pd().set_bit());
+
+    info!("Enabling GPIO1 clock");
+    pac.clkctl1.pscctl1_set().write(|w| w.hsgpio1_clk_set().set_clock());
+
+    // Take GPIO0 out of reset
+    info!("Clearing GPIO1 reset");
+    pac.rstctl1.prstctl1_clr().write(|w| w.hsgpio1_rst_clr().clr_reset());
+}

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -1,0 +1,67 @@
+#![no_std]
+#![no_main]
+
+use defmt::{error, info};
+use embassy_executor::Spawner;
+use embassy_imxrt::i2c::{self, I2cSlaveBlocking};
+use embassy_imxrt::iopctl::Pull;
+use embassy_imxrt::pac;
+
+const SLAVE_ADDR: Option<i2c::Address> = i2c::Address::new(0x20);
+
+fn wait_for_magic(i2c: &impl I2cSlaveBlocking) {
+    info!("i2cs example - waiting for ping");
+
+    match i2c.block_until_addressed() {
+        Ok(_) => info!("i2cs example - ping successfully received!"),
+        Err(e) => error!("i2cs example - ping exited with {:?}", e),
+    }
+
+    info!("i2cs example - wait for magic code 0xDEADBEEF");
+    let magic_code = [0xDE, 0xAD, 0xBE, 0xEF];
+    let mut received: [u8; 4] = [0; 4];
+
+    match i2c.read(&mut received) {
+        Ok(_) => {
+            info!("i2cs example - read(4) success! Checking Code");
+
+            for (rx, mg) in (&received).iter().zip(magic_code.iter()) {
+                if rx != mg {
+                    error!("Mismatch got {:?} but expected {:?}", rx, mg);
+                }
+            }
+        }
+        Err(e) => error!("i2cs example - read(4) exited with {:?}", e),
+    }
+
+    info!("i2cs example - writing back magic code to host");
+
+    match i2c.write(&magic_code) {
+        Ok(_) => info!("i2c example - write(4) successfully received!"),
+        Err(e) => error!("i2c example - write(4) exited with {:?}", e),
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // NOTE: tested with a raspberry pi 5 as master controller. Commands used:
+    // $ i2cdetect -y 1
+    // $ i2ctransfer -y 1 w4@0x20 0xDE 0xAD 0xBE 0xEF r4
+
+    let pac = pac::Peripherals::take().unwrap();
+
+    // Ensure SFRO Clock is set to run (power down is cleared)
+    pac.sysctl0.pdruncfg0_clr().write(|w| w.sfro_pd().set_bit());
+
+    info!("i2cs example - embassy_imxrt::init");
+    let p = embassy_imxrt::init(Default::default());
+
+    info!("i2cs example - I2c::new");
+    let i2c = i2c::I2cSlave::new(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Pull::Down, SLAVE_ADDR.unwrap()).unwrap();
+
+    embassy_imxrt_examples::delay(500);
+
+    loop {
+        wait_for_magic(&i2c);
+    }
+}

--- a/src/flexcomm.rs
+++ b/src/flexcomm.rs
@@ -1,0 +1,437 @@
+//! implements flexcomm interface wrapper for easier usage across modules
+
+use crate::{pac, Peripheral, PeripheralRef};
+
+/// alias for fc0::Registers, as layout is the same across all FCn
+pub type FlexcommRegisters = pac::flexcomm0::RegisterBlock;
+
+/// alias for i2c0::Registers, as layout is the same across all FCn
+pub type I2cRegisters = pac::i2c0::RegisterBlock;
+
+/// alias for spi0::Registers, as layout is the same across all FCn
+pub type SpiRegisters = pac::spi0::RegisterBlock;
+
+/// alias for i2s0::Registers, as layout is the same across all FCn
+pub type I2sRegisters = pac::i2s0::RegisterBlock;
+
+/// alias for usart0::Registers, as layout is the same across all FCn
+pub type UsartRegisters = pac::usart0::RegisterBlock;
+
+/// clock selection option
+#[derive(Copy, Clone, Debug)]
+pub enum Clock {
+    /// SFRO
+    Sfro,
+
+    /// FFRO
+    Ffro,
+
+    /// AUDIO_PLL
+    AudioPll,
+
+    /// MASTER
+    Master,
+
+    /// FCn_FRG
+    FcnFrg,
+
+    /// disabled
+    None,
+}
+
+/// what mode to configure this FCn to
+pub enum Mode {
+    /// i2c operation
+    I2c,
+
+    /// spi operation
+    Spi,
+
+    /// i2s transmit operation
+    I2sTx,
+
+    /// i2s receive operation
+    I2sRx,
+
+    /// usart operation
+    Usart,
+
+    /// no peripheral function selected
+    None,
+}
+
+/// do not allow implementation of trait outside this mod
+mod sealed {
+    /// trait does not get re-exported outside flexcomm mod, allowing us to safely expose only desired APIs
+    pub trait Sealed {}
+}
+
+/// potential configuration error reporting
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// feature not present on FCn (such as no SPI or I2S support)
+    FeatureNotPresent,
+}
+
+/// shorthand for ->Result<T>
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// primary low-level flexcomm interface
+trait FlexcommLowLevel: sealed::Sealed + Peripheral {
+    // fetch the flexcomm register block for direct manipulation
+    fn reg() -> &'static FlexcommRegisters;
+
+    // fetch the i2c peripheral registers for this FCn, if they exist
+    fn i2c() -> &'static I2cRegisters;
+
+    // fetch the SPI peripheral registers for this FCn, if they exist
+    fn spi() -> &'static SpiRegisters;
+
+    // fetch the I2S peripheral registers for this FCn, if they exist
+    fn i2s() -> &'static I2sRegisters;
+
+    // fetch the USART peripheral registers for this FCn, if they exist
+    fn usart() -> &'static UsartRegisters;
+
+    // set the clock select for this flexcomm instance and remove from reset
+    fn enable(clk: Clock);
+
+    // attempt to configure bus to operating mode
+    fn set_mode(mode: Mode) -> Result<()>;
+}
+
+/// internal shared I2C peripheral operations
+#[allow(private_bounds)]
+pub(crate) trait I2cPeripheral: FlexcommLowLevel {}
+
+/// Flexcomm configured for I2C usage
+#[allow(private_bounds)]
+pub struct I2cBus<'p, F: I2cPeripheral> {
+    _fc: PeripheralRef<'p, F>,
+}
+#[allow(private_bounds)]
+impl<'p, F: I2cPeripheral> I2cBus<'p, F> {
+    /// use Flexcomm fc as an I2c Bus
+    pub fn new(fc: impl I2cPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
+        F::enable(clk);
+        F::set_mode(Mode::I2c)?;
+        Ok(Self { _fc: fc.into_ref() })
+    }
+
+    /// retrieve active bus registers
+    pub fn i2c(&self) -> &'static I2cRegisters {
+        F::i2c()
+    }
+}
+
+/// internal shared SPI peripheral operations
+#[allow(private_bounds)]
+pub(crate) trait SpiPeripheral: FlexcommLowLevel {}
+
+/// Flexcomm configured for SPI usage
+#[allow(private_bounds)]
+pub struct SpiBus<'p, F: SpiPeripheral> {
+    _fc: PeripheralRef<'p, F>,
+}
+#[allow(private_bounds)]
+impl<'p, F: SpiPeripheral> SpiBus<'p, F> {
+    /// use Flexcomm fc as an SPI Bus
+    pub fn new(fc: impl SpiPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
+        F::enable(clk);
+        F::set_mode(Mode::Spi)?;
+        Ok(Self { _fc: fc.into_ref() })
+    }
+
+    /// retrieve active bus registers
+    pub fn spi(&self) -> &'static SpiRegisters {
+        F::spi()
+    }
+}
+
+/// internal shared I2S peripheral operations
+#[allow(private_bounds)]
+pub(crate) trait I2sPeripheral: FlexcommLowLevel {}
+
+/// Flexcomm configured for I2sTx usage
+#[allow(private_bounds)]
+pub struct I2sTransmit<'p, F: I2sPeripheral> {
+    _fc: PeripheralRef<'p, F>,
+}
+#[allow(private_bounds)]
+impl<'p, F: I2sPeripheral> I2sTransmit<'p, F> {
+    /// use Flexcomm fc as an I2sTx Bus
+    pub fn new(fc: impl I2sPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
+        F::enable(clk);
+        F::set_mode(Mode::I2sTx)?;
+        Ok(Self { _fc: fc.into_ref() })
+    }
+
+    /// retrieve active bus registers
+    pub fn i2s(&self) -> &'static I2sRegisters {
+        F::i2s()
+    }
+}
+
+/// Flexcomm configured for I2sRx usage
+#[allow(private_bounds)]
+pub struct I2sReceive<'p, F: I2sPeripheral> {
+    _fc: PeripheralRef<'p, F>,
+}
+#[allow(private_bounds)]
+impl<'p, F: I2sPeripheral> I2sReceive<'p, F> {
+    /// use Flexcomm fc as an I2sRx Bus
+    pub fn new(fc: impl I2sPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
+        F::enable(clk);
+        F::set_mode(Mode::I2sRx)?;
+        Ok(Self { _fc: fc.into_ref() })
+    }
+
+    /// retrieve active bus registers
+    pub fn i2s(&self) -> &'static I2sRegisters {
+        F::i2s()
+    }
+}
+
+/// internal shared USARt peripheral operations
+#[allow(private_bounds)]
+pub(crate) trait UsartPeripheral: FlexcommLowLevel {}
+
+/// Flexcomm configured for USART usage
+#[allow(private_bounds)]
+pub struct UsartBus<'p, F: UsartPeripheral> {
+    _fc: PeripheralRef<'p, F>,
+}
+#[allow(private_bounds)]
+impl<'p, F: UsartPeripheral> UsartBus<'p, F> {
+    /// use Flexcomm fc as an USART Bus
+    pub fn new(fc: impl UsartPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
+        F::enable(clk);
+        F::set_mode(Mode::Usart)?;
+        Ok(Self { _fc: fc.into_ref() })
+    }
+
+    /// retrieve active bus registers
+    pub fn usart(&self) -> &'static UsartRegisters {
+        F::usart()
+    }
+}
+
+macro_rules! impl_flexcomm {
+    ($fcn:expr, $ufc:ident, $lfc:ident, $i2c:ident, $spi:ident, $i2s:ident, $usart:ident, $fc_clk_set:ident, $fc_rst_clr:ident) => {
+        impl sealed::Sealed for crate::peripherals::$ufc {}
+        impl I2cPeripheral for crate::peripherals::$ufc {}
+        impl SpiPeripheral for crate::peripherals::$ufc {}
+        impl I2sPeripheral for crate::peripherals::$ufc {}
+        impl UsartPeripheral for crate::peripherals::$ufc {}
+
+        impl FlexcommLowLevel for crate::peripherals::$ufc {
+            fn reg() -> &'static FlexcommRegisters {
+                // SAFETY: safe from single executor, enforce via peripheral reference lifetime tracking
+                unsafe { &*crate::pac::$lfc::ptr() }
+            }
+
+            fn i2c() -> &'static I2cRegisters {
+                // SAFETY: safe from single executor, enforce via peripheral reference lifetime tracking
+                unsafe { &*crate::pac::$i2c::ptr() }
+            }
+
+            fn spi() -> &'static SpiRegisters {
+                // SAFETY: safe from single executor, enforce via peripheral reference lifetime tracking
+                unsafe { &*crate::pac::$spi::ptr() }
+            }
+
+            fn i2s() -> &'static I2sRegisters {
+                // SAFETY: safe from single executor, enforce via peripheral reference lifetime tracking
+                unsafe { &*crate::pac::$i2s::ptr() }
+            }
+
+            fn usart() ->&'static UsartRegisters {
+                // SAFETY: safe from single executor, enforce via peripheral reference lifetime tracking
+                unsafe { &*crate::pac::$usart::ptr() }
+            }
+
+            fn enable(clk: Clock) {
+                // From Section 21.4 (pg. 544) for Flexcomm in User Manual, enable fc[n]_clk
+
+                // SAFETY: safe from single executor
+                let clkctl1 = unsafe { crate::pac::Clkctl1::steal() };
+
+                clkctl1.pscctl0_set().write(|w| w.$fc_clk_set().set_clock());
+
+                clkctl1.flexcomm($fcn).fcfclksel().write(|w| match clk {
+                    Clock::Sfro => w.sel().sfro_clk(),
+                    Clock::Ffro => w.sel().ffro_clk(),
+                    Clock::AudioPll => w.sel().audio_pll_clk(),
+                    Clock::Master => w.sel().master_clk(),
+                    Clock::FcnFrg => w.sel().fcn_frg_clk(),
+                    Clock::None => w.sel().none(),
+                });
+                clkctl1.flexcomm($fcn).frgclksel().write(|w| match clk {
+                    Clock::Sfro => w.sel().sfro_clk(),
+                    Clock::Ffro => w.sel().ffro_clk(),
+                    Clock::AudioPll => w.sel().frg_pll_clk(),
+                    Clock::Master => w.sel().main_clk(),
+                    Clock::FcnFrg => w.sel().frg_pll_clk(),
+                    Clock::None => w.sel().none(),
+                });
+                clkctl1
+                    .flexcomm($fcn)
+                    .frgctl()
+                    .write(|w|
+                        // SAFETY: unsafe only used for .bits() call
+                        unsafe { w.mult().bits(0) });
+
+                // SAFETY: safe from single executor
+                let rstctl1 = unsafe { crate::pac::Rstctl1::steal() };
+
+                rstctl1.prstctl0_clr().write(|w| w.$fc_rst_clr().set_bit());
+            }
+
+            fn set_mode(mode: Mode) -> Result<()> {
+                let fc = Self::reg();
+
+                match mode {
+                    Mode::I2c => {
+                        if fc.pselid().read().i2cpresent().is_present() {
+                            fc.pselid().write(|w| w.persel().i2c());
+                            Ok(())
+                        } else {
+                            Err(Error::FeatureNotPresent)
+                        }
+                    }
+                    Mode::Spi => {
+                        if fc.pselid().read().spipresent().is_present() {
+                            fc.pselid().write(|w| w.persel().spi());
+                            Ok(())
+                        } else {
+                            Err(Error::FeatureNotPresent)
+                        }
+                    }
+                    Mode::I2sTx => {
+                        if fc.pselid().read().i2spresent().is_present() {
+                            fc.pselid().write(|w| w.persel().i2s_transmit());
+                            Ok(())
+                        } else {
+                            Err(Error::FeatureNotPresent)
+                        }
+                    }
+                    Mode::I2sRx => {
+                        if fc.pselid().read().i2spresent().is_present() {
+                            fc.pselid().write(|w| w.persel().i2s_receive());
+                            Ok(())
+                        } else {
+                            Err(Error::FeatureNotPresent)
+                        }
+                    }
+                    Mode::Usart => {
+                        if fc.pselid().read().usartpresent().is_present() {
+                            fc.pselid().write(|w| w.persel().usart());
+                            Ok(())
+                        } else {
+                            Err(Error::FeatureNotPresent)
+                        }
+                    }
+                    Mode::None => {
+                        fc.pselid().write(|w| w.persel().no_periph_selected());
+                        Ok(())
+                    }
+                }
+            }
+        }
+
+    };
+}
+
+impl_flexcomm!(
+    0,
+    FLEXCOMM0,
+    Flexcomm0,
+    I2c0,
+    Spi0,
+    I2s0,
+    Usart0,
+    fc0_clk_set,
+    flexcomm0_rst_clr
+);
+impl_flexcomm!(
+    1,
+    FLEXCOMM1,
+    Flexcomm1,
+    I2c1,
+    Spi1,
+    I2s1,
+    Usart1,
+    fc1_clk_set,
+    flexcomm1_rst_clr
+);
+impl_flexcomm!(
+    2,
+    FLEXCOMM2,
+    Flexcomm2,
+    I2c2,
+    Spi2,
+    I2s2,
+    Usart2,
+    fc2_clk_set,
+    flexcomm2_rst_clr
+);
+impl_flexcomm!(
+    3,
+    FLEXCOMM3,
+    Flexcomm3,
+    I2c3,
+    Spi3,
+    I2s3,
+    Usart3,
+    fc3_clk_set,
+    flexcomm3_rst_clr
+);
+impl_flexcomm!(
+    4,
+    FLEXCOMM4,
+    Flexcomm4,
+    I2c4,
+    Spi4,
+    I2s4,
+    Usart4,
+    fc4_clk_set,
+    flexcomm4_rst_clr
+);
+impl_flexcomm!(
+    5,
+    FLEXCOMM5,
+    Flexcomm5,
+    I2c5,
+    Spi5,
+    I2s5,
+    Usart5,
+    fc5_clk_set,
+    flexcomm5_rst_clr
+);
+impl_flexcomm!(
+    6,
+    FLEXCOMM6,
+    Flexcomm6,
+    I2c6,
+    Spi6,
+    I2s6,
+    Usart6,
+    fc6_clk_set,
+    flexcomm6_rst_clr
+);
+impl_flexcomm!(
+    7,
+    FLEXCOMM7,
+    Flexcomm7,
+    I2c7,
+    Spi7,
+    I2s7,
+    Usart7,
+    fc7_clk_set,
+    flexcomm7_rst_clr
+);
+
+// TODO: in follow up flexcomm PR, implement special FC14 + FC15 support
+//impl_flexcomm!(14, FLEXCOMM14, Flexcomm14, I2c14, Spi14, I2s14, Usart14);
+//impl_flexcomm!(15, FLEXCOMM15, Flexcomm15, I2c15, Sp157, I2s15, Usart15);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,696 @@
+//! Implements I2C function support over flexcomm + gpios
+
+#[cfg(feature = "time")]
+use embassy_time::{Duration, Instant};
+
+use crate::iopctl::IopctlPin as Pin;
+use crate::PeripheralRef;
+
+/// Bus speed (nominal SCL, no clock stretching)
+pub enum Speed {
+    /// 100 kbit/s
+    Standard,
+
+    /// 400 kbit/s
+    Fast,
+
+    /// 1 Mbit/s
+    FastPlus,
+
+    /// 3.4Mbit/s only available for slave devices
+    High,
+}
+
+/// I2C address type
+#[derive(Copy, Clone, Debug)]
+pub struct Address(u8);
+
+impl Address {
+    /// Construct an address type
+    pub const fn new(addr: u8) -> Option<Self> {
+        match addr {
+            0x08..=0x77 => Some(Self(addr)),
+            _ => None,
+        }
+    }
+
+    /// interpret address as a read command
+    pub fn read(&self) -> u8 {
+        (self.0 << 1) | 1
+    }
+
+    /// interpret address as a write command
+    pub fn write(&self) -> u8 {
+        self.0 << 1
+    }
+}
+
+impl From<Address> for u8 {
+    fn from(value: Address) -> Self {
+        value.0
+    }
+}
+
+/// specific information regarding transfer errors
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TransferError {
+    /// Timeout error
+    Timeout,
+    /// Reading from i2c failed
+    ReadFail,
+    /// Writing to i2c failed
+    WriteFail,
+    /// I2C Address not ACK'd
+    AddressNack,
+}
+
+/// Error information type
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// propagating a lower level flexcomm error
+    Flex(crate::flexcomm::Error),
+
+    /// configuration requested is not supported
+    UnsupportedConfiguration,
+
+    /// transaction failure types
+    Transfer(TransferError),
+}
+
+/// shorthand for -> Result<T>
+pub type Result<T> = core::result::Result<T, Error>;
+
+// implementing from allows ? operator from flexcomm::Result<T>
+impl From<crate::flexcomm::Error> for Error {
+    fn from(value: crate::flexcomm::Error) -> Self {
+        Error::Flex(value)
+    }
+}
+
+impl From<TransferError> for Error {
+    fn from(value: TransferError) -> Self {
+        Error::Transfer(value)
+    }
+}
+
+mod sealed {
+    /// simply seal a trait
+    pub trait Sealed {}
+}
+
+impl<T: Pin> sealed::Sealed for T {}
+
+/// shared functions between master and slave operation
+#[allow(private_bounds)]
+pub trait I2cAny<const FC: usize>: crate::flexcomm::I2cPeripheral {}
+impl I2cAny<0> for crate::peripherals::FLEXCOMM0 {}
+impl I2cAny<1> for crate::peripherals::FLEXCOMM1 {}
+impl I2cAny<2> for crate::peripherals::FLEXCOMM2 {}
+impl I2cAny<3> for crate::peripherals::FLEXCOMM3 {}
+impl I2cAny<4> for crate::peripherals::FLEXCOMM4 {}
+impl I2cAny<5> for crate::peripherals::FLEXCOMM5 {}
+impl I2cAny<6> for crate::peripherals::FLEXCOMM6 {}
+impl I2cAny<7> for crate::peripherals::FLEXCOMM7 {}
+
+/// io configuration trait for easier configuration
+pub trait SclPin<const FC: usize>: Pin + sealed::Sealed + crate::Peripheral {
+    /// convert the pin to appropriate function for SCL usage
+    fn as_scl(&self, pull: crate::iopctl::Pull);
+}
+
+/// io configuration trait for easier configuration
+pub trait SdaPin<const FC: usize>: Pin + sealed::Sealed + crate::Peripheral {
+    /// convert the pin to appropriate function for SDA usage
+    fn as_sda(&self, pull: crate::iopctl::Pull);
+}
+
+/// use FCn as I2C Master controller
+pub struct I2cMaster<'a, const FC: usize, T: I2cAny<FC>, SCL: SclPin<FC>, SDA: SdaPin<FC>> {
+    bus: crate::flexcomm::I2cBus<'a, T>,
+    _scl: PeripheralRef<'a, SCL>,
+    _sda: PeripheralRef<'a, SDA>,
+    timeout: TimeoutSettings,
+    #[cfg(feature = "time")]
+    poll_start: Instant,
+}
+
+/// use FCn as I2C Slave controller
+pub struct I2cSlave<'a, const FC: usize, T: I2cAny<FC>, SCL: SclPin<FC>, SDA: SdaPin<FC>> {
+    bus: crate::flexcomm::I2cBus<'a, T>,
+    _scl: PeripheralRef<'a, SCL>,
+    _sda: PeripheralRef<'a, SDA>,
+}
+
+/// configuration struct for i2c master timeout control
+pub struct TimeoutSettings {
+    /// true - enable HW based timeout, false - disable
+    pub hw_timeout: bool,
+
+    /// software driven timeout duration, if time feature is enabled
+    #[cfg(feature = "time")]
+    pub sw_timeout: Duration,
+}
+
+impl<'a, const FC: usize, T: I2cAny<FC, P = T>, SCL: SclPin<FC, P = SCL>, SDA: SdaPin<FC, P = SDA>>
+    I2cMaster<'a, FC, T, SCL, SDA>
+{
+    /// use flexcomm fc with Pins scl, sda as an I2C Master bus, configuring to speed and pull
+    pub fn new(
+        fc: T,
+        scl: SCL,
+        sda: SDA,
+        // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
+        pull: crate::iopctl::Pull,
+        speed: Speed,
+        timeout: TimeoutSettings,
+    ) -> Result<Self> {
+        // TODO - clock integration
+        let clock = crate::flexcomm::Clock::Sfro;
+
+        sda.as_sda(pull);
+        scl.as_scl(pull);
+
+        let bus = crate::flexcomm::I2cBus::new(fc, clock)?;
+
+        // this check should be redundant with T::set_mode()? above
+
+        // rates taken assuming SFRO:
+        //
+        //  7 => 403.3 kHz
+        //  9 => 322.6 kHz
+        // 12 => 247.8 kHz
+        // 16 => 198.2 kHz
+        // 18 => 166.6 Khz
+        // 22 => 142.6 kHz
+        // 30 => 100.0 kHz
+        match speed {
+            // 100 kHz
+            Speed::Standard => bus.i2c().clkdiv().write(|w|
+                // SAFETY: only unsafe due to .bits usage
+                unsafe { w.divval().bits(30) }),
+
+            // 400 kHz
+            Speed::Fast => bus.i2c().clkdiv().write(|w|
+                // SAFETY: only unsafe due to .bits usage
+                unsafe { w.divval().bits(7) }),
+
+            _ => return Err(Error::UnsupportedConfiguration),
+        }
+
+        bus.i2c().msttime().write(|w|
+            // SAFETY: only unsafe due to .bits usage
+            unsafe { w.mstsclhigh().bits(0).mstscllow().bits(1) });
+
+        if timeout.hw_timeout {
+            bus.i2c().timeout().write(|w|
+                    // SAFETY: only unsafe due to .bits usage
+                unsafe { w.to().bits(4096 >> 4) });
+
+            bus.i2c().cfg().modify(|_, w| w.timeouten().enabled());
+        }
+
+        bus.i2c().intenset().write(|w|
+                // SAFETY: only unsafe due to .bits usage
+                unsafe { w.bits(0) });
+
+        bus.i2c().cfg().write(|w| w.msten().set_bit());
+        let mut this = Self {
+            bus,
+            _scl: scl.into_ref(),
+            _sda: sda.into_ref(),
+            timeout,
+            #[cfg(feature = "time")]
+            poll_start: Instant::now(),
+        };
+        this.poll_ready()?;
+
+        Ok(this)
+    }
+
+    fn read_no_stop(&mut self, address: u8, read: &mut [u8]) -> Result<()> {
+        let i2cregs = self.bus.i2c();
+
+        i2cregs.mstdat().write(|w|
+            // SAFETY: only unsafe due to .bits usage
+            unsafe { w.data().bits(address << 1 | 0x01) });
+        i2cregs.mstctl().write(|w| w.mststart().set_bit());
+        self.poll_ready()?;
+
+        for r in read {
+            while i2cregs.stat().read().mstpending().bit_is_clear() {}
+            *r = (i2cregs.mstdat().read().bits() & 0xFF) as u8;
+        }
+
+        Ok(())
+    }
+
+    fn write_no_stop(&mut self, address: u8, write: &[u8]) -> Result<()> {
+        // Procedure from 24.3.1.1 pg 545
+        let i2cregs = self.bus.i2c();
+
+        i2cregs.mstdat().write(|w|
+        // SAFETY: unsafe only due to .bits usage
+        unsafe { w.data().bits(address << 1) });
+        i2cregs.mstctl().write(|w| w.mststart().set_bit());
+        self.poll_ready()?;
+
+        for byte in write.iter() {
+            i2cregs.mstdat().write(|w|
+            // SAFETY: unsafe only due to .bits usage
+            unsafe { w.data().bits(*byte) });
+            i2cregs.mstctl().write(|w| w.mstcontinue().set_bit());
+            self.poll_ready()?;
+        }
+
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        // Procedure from 24.3.1.1 pg 545
+        let i2cregs = self.bus.i2c();
+
+        i2cregs.mstctl().write(|w| w.mststop().set_bit());
+        self.poll_ready()?;
+
+        Ok(())
+    }
+
+    fn check_timeout(&mut self) -> Result<()> {
+        let stat = self.bus.i2c().stat().read();
+        if self.timeout.hw_timeout && (stat.scltimeout().bit_is_set() || stat.eventtimeout().is_even_timeout()) {
+            Err(TransferError::Timeout.into())
+        } else {
+            #[cfg(feature = "time")]
+            {
+                if Instant::now() - self.poll_start >= self.timeout.sw_timeout {
+                    return Err(TransferError::Timeout.into());
+                }
+            }
+
+            Ok(())
+        }
+    }
+
+    fn poll_ready(&mut self) -> Result<()> {
+        #[cfg(feature = "time")]
+        {
+            self.poll_start = Instant::now();
+        }
+
+        while self.bus.i2c().stat().read().mstpending().bit_is_clear() {
+            self.check_timeout()?;
+        }
+
+        Ok(())
+    }
+}
+
+// re-export embedded-hal I2c trait
+pub use embedded_hal_1::i2c::{ErrorType as I2cMasterBlockingErrorType, I2c as I2cMasterBlocking};
+
+/// Error Types for I2C communication
+impl embedded_hal_1::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal_1::i2c::ErrorKind {
+        match *self {
+            Self::Flex(_) => embedded_hal_1::i2c::ErrorKind::Bus,
+            Self::UnsupportedConfiguration => embedded_hal_1::i2c::ErrorKind::Other,
+            Self::Transfer(e) => match e {
+                TransferError::Timeout => embedded_hal_1::i2c::ErrorKind::Other,
+                TransferError::ReadFail | TransferError::WriteFail => {
+                    embedded_hal_1::i2c::ErrorKind::NoAcknowledge(embedded_hal_1::i2c::NoAcknowledgeSource::Data)
+                }
+                TransferError::AddressNack => {
+                    embedded_hal_1::i2c::ErrorKind::NoAcknowledge(embedded_hal_1::i2c::NoAcknowledgeSource::Address)
+                }
+            },
+        }
+    }
+}
+
+impl<'a, const FC: usize, T: I2cAny<FC, P = T>, SCL: SclPin<FC, P = SCL>, SDA: SdaPin<FC, P = SDA>>
+    I2cMasterBlockingErrorType for I2cMaster<'a, FC, T, SCL, SDA>
+{
+    type Error = Error;
+}
+
+// implement generic i2c interface for peripheral master type
+impl<'a, const FC: usize, T: I2cAny<FC, P = T>, SCL: SclPin<FC, P = SCL>, SDA: SdaPin<FC, P = SDA>> I2cMasterBlocking
+    for I2cMaster<'a, FC, T, SCL, SDA>
+{
+    fn read(&mut self, address: u8, read: &mut [u8]) -> Result<()> {
+        // Procedure from 24.3.1.2 pg 546
+        let i2cregs = self.bus.i2c();
+
+        i2cregs.mstdat().write(|w|
+            // SAFETY: only unsafe due to .bits usage
+            unsafe { w.data().bits(address << 1 | 0x01) });
+        i2cregs.mstctl().write(|w| w.mststart().set_bit());
+        self.poll_ready()?;
+
+        for r in read {
+            self.poll_ready()?;
+            *r = (i2cregs.mstdat().read().bits() & 0xFF) as u8;
+        }
+
+        i2cregs.mstctl().write(|w| w.mststop().set_bit());
+        self.poll_ready()?;
+
+        Ok(())
+    }
+
+    fn write(&mut self, address: u8, write: &[u8]) -> Result<()> {
+        // Procedure from 24.3.1.1 pg 545
+        let i2cregs = self.bus.i2c();
+
+        i2cregs.mstdat().write(|w|
+        // SAFETY: unsafe only due to .bits usage
+        unsafe { w.data().bits(address << 1) });
+        i2cregs.mstctl().write(|w| w.mststart().set_bit());
+        self.poll_ready()?;
+
+        for byte in write.iter() {
+            i2cregs.mstdat().write(|w|
+            // SAFETY: unsafe only due to .bits usage
+            unsafe { w.data().bits(*byte) });
+            i2cregs.mstctl().write(|w| w.mstcontinue().set_bit());
+            self.poll_ready()?;
+        }
+
+        i2cregs.mstctl().write(|w| w.mststop().set_bit());
+        self.poll_ready()?;
+
+        Ok(())
+    }
+
+    fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<()> {
+        let i2cregs = self.bus.i2c();
+
+        i2cregs.mstdat().write(|w|
+            // SAFETY: only unsafe due to .bits usage
+            unsafe { w.data().bits(address << 1) });
+
+        i2cregs.mstctl().write(|w| w.mststart().set_bit());
+        self.poll_ready()?;
+
+        if i2cregs.stat().read().mststate().is_nack_address() {
+            // STOP bit to complete the attempted transfer
+            i2cregs.mstctl().write(|w| w.mststop().set_bit());
+            self.poll_ready()?;
+
+            return Err(Error::Transfer(TransferError::AddressNack));
+        }
+
+        for byte in write.iter() {
+            i2cregs.mstdat().write(|w|
+            // SAFETY: only unsafe due to .bits usage
+            unsafe { w.data().bits(*byte) });
+            i2cregs.mstctl().write(|w| w.mstcontinue().set_bit());
+            self.poll_ready()?;
+        }
+
+        i2cregs.mstdat().write(|w|
+        // SAFETY: only unsafe due to .bits usage
+        unsafe { w.data().bits((address << 1) | 1) });
+        i2cregs.mstctl().write(|w| w.mststart().set_bit());
+        self.poll_ready()?;
+
+        if i2cregs.stat().read().mststate().is_nack_address() {
+            // STOP bit to complete the attempted transfer
+            i2cregs.mstctl().write(|w| w.mststop().set_bit());
+            self.poll_ready()?;
+
+            return Err(TransferError::AddressNack.into());
+        }
+
+        for r in read {
+            self.poll_ready()?;
+
+            if i2cregs.stat().read().mststate().is_nack_data() {
+                return Err(TransferError::ReadFail.into());
+            }
+            *r = i2cregs.mstdat().read().data().bits();
+        }
+
+        i2cregs.mstctl().write(|w| w.mststop().set_bit());
+        self.poll_ready()?;
+
+        Ok(())
+    }
+
+    fn transaction(&mut self, address: u8, operations: &mut [embedded_hal_1::i2c::Operation<'_>]) -> Result<()> {
+        let needs_stop = !operations.is_empty();
+
+        for op in operations {
+            match op {
+                embedded_hal_1::i2c::Operation::Read(read) => {
+                    self.read_no_stop(address, read)?;
+                }
+                embedded_hal_1::i2c::Operation::Write(write) => {
+                    self.write_no_stop(address, write)?;
+                }
+            }
+        }
+
+        if needs_stop {
+            self.stop()?;
+        }
+
+        Ok(())
+    }
+}
+
+/// interface trait for generalized I2C slave interactions
+pub trait I2cSlaveBlocking {
+    /// block until the address is pinged (expect no payload)
+    fn block_until_addressed(&self) -> Result<()>;
+
+    /// wait for a read request
+    fn read(&self, read: &mut [u8]) -> Result<()>;
+
+    /// wait for a write request
+    fn write(&self, write: &[u8]) -> Result<()>;
+}
+
+impl<'a, const FC: usize, T: I2cAny<FC, P = T>, SCL: SclPin<FC, P = SCL>, SDA: SdaPin<FC, P = SDA>>
+    I2cSlave<'a, FC, T, SCL, SDA>
+{
+    /// use flexcomm fc with Pins scl, sda as an I2C Master bus, configuring to speed and pull
+    pub fn new(
+        fc: T,
+        scl: SCL,
+        sda: SDA,
+        // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
+        pull: crate::iopctl::Pull,
+        address: Address,
+    ) -> Result<Self> {
+        // TODO - clock integration
+        let clock = crate::flexcomm::Clock::Sfro;
+
+        sda.as_sda(pull);
+        scl.as_scl(pull);
+
+        let bus = crate::flexcomm::I2cBus::new(fc, clock)?;
+
+        // this check should be redundant with T::set_mode()? above
+        let i2c = bus.i2c();
+
+        // rates taken assuming SFRO:
+        //
+        //  7 => 403.3 kHz
+        //  9 => 322.6 kHz
+        // 12 => 247.8 kHz
+        // 16 => 198.2 kHz
+        // 18 => 166.6 Khz
+        // 22 => 142.6 kHz
+        // 30 => 100.0 kHz
+        // UM10204 pg.44 rev7
+        // tSU;DAT >= 250ns -> < 250MHz
+        i2c.clkdiv().write(|w|
+            // SAFETY: only unsafe due to .bits usage
+            unsafe { w.divval().bits(0) });
+
+        // address 0 match = addr, per UM11147 24.3.2.1
+        i2c.slvadr(0).modify(|_, w|
+            // note: shift is omitted as performed via w.slvadr() 
+            // SAFETY: unsafe only required due to use of unnamed "bits" field
+            unsafe {w.slvadr().bits(address.0)}.sadisable().enabled());
+
+        // SLVEN = 1, per UM11147 24.3.2.1
+        i2c.cfg().write(|w| w.slven().enabled());
+
+        Ok(Self {
+            bus,
+            _scl: scl.into_ref(),
+            _sda: sda.into_ref(),
+        })
+    }
+
+    fn poll(&self) -> Result<()> {
+        let i2c = self.bus.i2c();
+
+        while i2c.stat().read().slvpending().is_in_progress() {}
+
+        Ok(())
+    }
+}
+
+impl<'a, const FC: usize, T: I2cAny<FC, P = T>, SCL: SclPin<FC, P = SCL>, SDA: SdaPin<FC, P = SDA>> I2cSlaveBlocking
+    for I2cSlave<'a, FC, T, SCL, SDA>
+{
+    fn block_until_addressed(&self) -> Result<()> {
+        self.poll()?;
+
+        let i2c = self.bus.i2c();
+
+        if !i2c.stat().read().slvstate().is_slave_address() {
+            return Err(TransferError::AddressNack.into());
+        }
+
+        i2c.slvctl().write(|w| w.slvcontinue().continue_());
+        Ok(())
+    }
+
+    fn read(&self, read: &mut [u8]) -> Result<()> {
+        let i2c = self.bus.i2c();
+
+        self.block_until_addressed()?;
+
+        for b in read {
+            self.poll()?;
+
+            if !i2c.stat().read().slvstate().is_slave_receive() {
+                return Err(TransferError::ReadFail.into());
+            }
+
+            *b = i2c.slvdat().read().data().bits();
+
+            i2c.slvctl().write(|w| w.slvcontinue().continue_());
+        }
+
+        Ok(())
+    }
+
+    fn write(&self, write: &[u8]) -> Result<()> {
+        let i2c = self.bus.i2c();
+
+        self.block_until_addressed()?;
+
+        for b in write {
+            self.poll()?;
+
+            if !i2c.stat().read().slvstate().is_slave_transmit() {
+                return Err(TransferError::WriteFail.into());
+            }
+
+            i2c.slvdat().write(|w|
+                // SAFETY: unsafe only here due to use of bits()
+                unsafe{w.data().bits(*b)});
+
+            i2c.slvctl().write(|w| w.slvcontinue().continue_());
+        }
+
+        Ok(())
+    }
+}
+
+// flexcomm <-> Pin function map
+macro_rules! impl_scl {
+    ($piom_n:ident, $fn:ident, $fcn:expr) => {
+        impl SclPin<$fcn> for crate::peripherals::$piom_n {
+            fn as_scl(&self, pull: crate::iopctl::Pull) {
+                // UM11147 table 299 pg 262+
+                self.set_pull(pull)
+                    .set_slew_rate(crate::gpio::SlewRate::Standard)
+                    .set_drive_strength(crate::gpio::DriveStrength::Normal)
+                    .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
+                    .set_input_polarity(crate::gpio::Polarity::ActiveHigh)
+                    .enable_input_buffer()
+                    .set_function(crate::iopctl::Function::$fn);
+            }
+        }
+    };
+}
+macro_rules! impl_sda {
+    ($piom_n:ident, $fn:ident, $fcn:expr) => {
+        impl SdaPin<$fcn> for crate::peripherals::$piom_n {
+            fn as_sda(&self, pull: crate::iopctl::Pull) {
+                // UM11147 table 299 pg 262+
+                self.set_pull(pull)
+                    .set_slew_rate(crate::gpio::SlewRate::Standard)
+                    .set_drive_strength(crate::gpio::DriveStrength::Normal)
+                    .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
+                    .set_input_polarity(crate::gpio::Polarity::ActiveHigh)
+                    .enable_input_buffer()
+                    .set_function(crate::iopctl::Function::$fn);
+            }
+        }
+    };
+}
+
+// Flexcomm0 GPIOs -
+impl_scl!(PIO0_1, F1, 0);
+impl_sda!(PIO0_2, F1, 0);
+
+impl_scl!(PIO3_1, F5, 0);
+impl_sda!(PIO3_2, F5, 0);
+impl_sda!(PIO3_3, F5, 0);
+impl_scl!(PIO3_4, F5, 0);
+
+// Flexcomm1 GPIOs -
+impl_scl!(PIO0_8, F1, 1);
+impl_sda!(PIO0_9, F1, 1);
+impl_sda!(PIO0_10, F1, 1);
+impl_scl!(PIO0_11, F1, 1);
+
+impl_scl!(PIO7_26, F1, 1);
+impl_sda!(PIO7_27, F1, 1);
+impl_sda!(PIO7_28, F1, 1);
+impl_scl!(PIO7_29, F1, 1);
+
+// Flexcomm2 GPIOs -
+impl_scl!(PIO0_15, F1, 2);
+impl_sda!(PIO0_16, F1, 2);
+impl_sda!(PIO0_17, F1, 2);
+impl_scl!(PIO0_18, F1, 2);
+
+impl_sda!(PIO4_8, F5, 2);
+
+impl_scl!(PIO7_30, F5, 2);
+impl_sda!(PIO7_31, F5, 2);
+
+// Flexcomm3 GPIOs -
+impl_scl!(PIO0_22, F1, 3);
+impl_sda!(PIO0_23, F1, 3);
+impl_sda!(PIO0_24, F1, 3);
+impl_scl!(PIO0_25, F1, 3);
+
+// Flexcomm4 GPIOs -
+impl_scl!(PIO0_29, F1, 4);
+impl_sda!(PIO0_30, F1, 4);
+impl_sda!(PIO0_31, F1, 4);
+impl_scl!(PIO1_0, F1, 4);
+
+// Flexcomm5 GPIOs -
+impl_scl!(PIO1_4, F1, 5);
+impl_sda!(PIO1_5, F1, 5);
+impl_sda!(PIO1_6, F1, 5);
+impl_scl!(PIO1_7, F1, 5);
+
+impl_scl!(PIO3_16, F4, 5);
+impl_sda!(PIO3_17, F4, 5);
+impl_sda!(PIO3_18, F4, 5);
+impl_scl!(PIO3_22, F5, 5);
+
+// Flexcomm6 GPIOs -
+impl_scl!(PIO3_26, F1, 6);
+impl_sda!(PIO3_27, F1, 6);
+impl_sda!(PIO3_28, F1, 6);
+impl_scl!(PIO3_29, F1, 6);
+
+// Flexcomm7 GPIOs -
+impl_scl!(PIO4_1, F1, 7);
+impl_sda!(PIO4_2, F1, 7);
+impl_sda!(PIO4_3, F1, 7);
+impl_scl!(PIO4_4, F1, 7);

--- a/src/iopctl.rs
+++ b/src/iopctl.rs
@@ -15,6 +15,8 @@ use crate::pac::{iopctl, Iopctl};
 type PioM_N = iopctl::Pio0_0;
 
 /// Pin function number.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Function {
     /// Function 0
     F0,
@@ -37,6 +39,8 @@ pub enum Function {
 }
 
 /// Internal pull-up/down resistors on a pin.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Pull {
     /// No pull-up or pull-down resistor selected
     None,
@@ -47,6 +51,8 @@ pub enum Pull {
 }
 
 /// Pin slew rate.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SlewRate {
     /// Standard slew rate
     Standard,
@@ -55,6 +61,8 @@ pub enum SlewRate {
 }
 
 /// Output drive strength of a pin.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DriveStrength {
     /// Normal
     Normal,
@@ -63,6 +71,8 @@ pub enum DriveStrength {
 }
 
 /// Output drive mode of a pin.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DriveMode {
     /// Push-Pull
     PushPull,
@@ -71,6 +81,8 @@ pub enum DriveMode {
 }
 
 /// Input polarity of a pin.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Polarity {
     /// Active-high
     ActiveHigh,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ pub(crate) mod fmt;
 
 pub mod adc;
 pub mod clocks;
+pub mod flexcomm;
 pub mod gpio;
+pub mod i2c;
 pub mod iopctl;
 pub mod pwm;
 #[cfg(feature = "time-driver")]


### PR DESCRIPTION
Implements I2C (Master + Slave mode) support for the RT6**. Some features introduced here are placeholders, to be expanded upon in future PRs (flexcomm).