### PR TITLE
Remove unnecessary `targets' setting

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-          targets: "thumbv8m.main-none-eabihf"
       - name: cargo fmt --check
         run: cargo fmt --check
   clippy:
@@ -55,7 +54,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
-          targets: "thumbv8m.main-none-eabihf"
       - name: cargo clippy
         uses: giraffate/clippy-action@v1
         with:
@@ -73,7 +71,6 @@ jobs:
   #       uses: dtolnay/rust-toolchain@stable
   #       with:
   #         components: rustfmt
-  #         targets: "thumbv8m.main-none-eabihf"
   #     - name: cargo-semver-checks
   #       uses: obi1kenobi/cargo-semver-checks-action@v2
   doc:
@@ -88,8 +85,6 @@ jobs:
           submodules: true
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: "thumbv8m.main-none-eabihf"
       - name: cargo doc
         run: cargo doc --no-deps --all-features
         env:
@@ -105,8 +100,6 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: "thumbv8m.main-none-eabihf"
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
@@ -158,6 +151,5 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.msrv }}
-          targets: "thumbv8m.main-none-eabihf"
       - name: cargo +${{ matrix.msrv }} check
         run: cargo check


### PR DESCRIPTION
embassy-imxrt should be able to compile with any rustc, even though it's only really useful for iMXRT targets.