### PR TITLE
Refactor flex pin to use typestate pattern

### DIFF
--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -5,6 +5,7 @@ use defmt::assert;
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
+use embassy_imxrt::gpio::{SenseDisabled, SenseEnabled};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
@@ -13,45 +14,64 @@ async fn main(_spawner: Spawner) {
     info!("Initializing GPIO");
     unsafe { gpio::init() };
 
-    let mut flex = gpio::Flex::new(p.PIO1_0);
+    let mut flex = gpio::Flex::<SenseDisabled>::new(p.PIO1_0);
 
     // set pin output bit to high before setting direction
     flex.set_high();
 
-    // set direction as output
-    flex.set_as_output(
+    let flex = flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveHigh);
+
+    // check pin level is high
+    assert!(flex.is_high());
+
+    let mut flex = flex.set_as_output(
         gpio::DriveMode::PushPull,
         gpio::DriveStrength::Normal,
         gpio::SlewRate::Standard,
     );
 
-    // check pin level is high
-    assert!(flex.is_high());
-
     // toggle pin
     flex.toggle();
+
+    let flex = flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveHigh);
 
     // check pin level is low
     assert!(flex.is_low());
 
+    let flex = flex.set_as_output(
+        gpio::DriveMode::PushPull,
+        gpio::DriveStrength::Normal,
+        gpio::SlewRate::Standard,
+    );
+
     // set pin direction to output with reverse polarity
-    flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveLow);
+    let flex = flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveLow);
 
     // check pin level is high
     assert!(flex.is_high());
 
+    let mut flex = flex.set_as_output(
+        gpio::DriveMode::PushPull,
+        gpio::DriveStrength::Normal,
+        gpio::SlewRate::Standard,
+    );
+
     // set pin output bit to high
     flex.set_high();
+
+    let flex = flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveLow);
 
     // check pin level is still high
     assert!(flex.is_high());
 
     // set pin direction to output again
-    flex.set_as_output(
+    let mut flex = flex.set_as_output(
         gpio::DriveMode::PushPull,
         gpio::DriveStrength::Normal,
         gpio::SlewRate::Standard,
     );
+
+    let flex = flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveHigh);
 
     // check pin level is now low
     assert!(flex.is_low());


### PR DESCRIPTION
Pretty big change to enforce input buffer disabling for output pins.