### PR TITLE
gpio: fix warning when building without `rt' feature

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -65,8 +65,10 @@ fn GPIO_INTA() {
     irq_handler(&GPIO_WAKERS);
 }
 
+#[cfg(feature = "rt")]
 struct BitIter(u32);
 
+#[cfg(feature = "rt")]
 impl Iterator for BitIter {
     type Item = u32;
 


### PR DESCRIPTION
Fix the following build warning:

warning: struct `BitIter` is never constructed
  --> src\gpio.rs:68:8
   |
68 | struct BitIter(u32);
   |        ^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `embassy-imxrt` (lib) generated 1 warning