### PR TITLE
Check each commit from a PR in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,6 @@
 # This workflow runs whenever a PR is opened or updated, or a commit is pushed to main. It runs
 # several checks:
+# - commit_list: produces a list of commits to be checked
 # - fmt: checks that the code is formatted according to rustfmt
 # - clippy: checks that the code does not contain any clippy warnings
 # - doc: checks that the code can be documented without errors
@@ -21,22 +22,59 @@ concurrency:
   cancel-in-progress: true
 name: check
 jobs:
+
+  commit_list:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get commit list (push)
+      id: get_commit_list_push
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        echo "id0=$GITHUB_SHA" > $GITHUB_OUTPUT
+        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
+        sed -n 's,^id[0-9]\+=\(.*\),- https://github.com/pop-project/embassy-imxrt/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
+
+    - name: Get commit list (PR)
+      id: get_commit_list_pr
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        git rev-list --reverse refs/remotes/origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | awk '{ print "id" NR "=" $1 }' > $GITHUB_OUTPUT
+        git diff --quiet ${{ github.event.pull_request.head.sha }} ${{ github.sha }} || echo "id0=$GITHUB_SHA" >> $GITHUB_OUTPUT
+        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
+        sed -n 's,^id[0-9]\+=\(.*\),- https://github.com/pop-project/embassy-imxrt/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
+
+    outputs:
+      commits: ${{ toJSON(steps.*.outputs.*) }}
+
   fmt:
     runs-on: ubuntu-latest
     name: nightly / fmt
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ matrix.commit }}
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - name: cargo fmt --check
         run: cargo fmt --check
+
   clippy:
     runs-on: ubuntu-latest
     name: ${{ matrix.toolchain }} / clippy
+    needs: commit_list
     permissions:
       contents: read
       checks: write
@@ -45,10 +83,12 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ matrix.commit }}
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -59,45 +99,66 @@ jobs:
         with:
           reporter: 'github-pr-check'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
   # Enable once we have a released crate
   # semver:
   #   runs-on: ubuntu-latest
   #   name: semver
+  #   needs: commit_list
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
   #   steps:
   #     - uses: actions/checkout@v4
   #       with:
   #         submodules: true
+  #         ref: ${{ matrix.commit }}
   #     - name: Install stable
   #       uses: dtolnay/rust-toolchain@stable
   #       with:
   #         components: rustfmt
   #     - name: cargo-semver-checks
   #       uses: obi1kenobi/cargo-semver-checks-action@v2
+
   doc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
     # API be documented as only available in some specific platforms.
     runs-on: ubuntu-latest
     name: nightly / doc
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ matrix.commit }}
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo doc
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs
+
   hack:
     # cargo-hack checks combinations of feature flags to ensure that features are all additive
     # which is required for feature unification
     runs-on: ubuntu-latest
     name: ubuntu / stable / features
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-hack
@@ -106,15 +167,22 @@ jobs:
       # --feature-powerset runs for every combination of features
       - name: cargo hack
         run: cargo hack --feature-powerset check
+
   deny:
     # cargo-deny checks licenses, advisories, sources, and bans for
     # our dependencies.
     runs-on: ubuntu-latest
     name: ubuntu / stable / deny
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-deny
@@ -124,13 +192,17 @@ jobs:
           manifest-path: ./Cargo.toml
           command: check
           arguments: --all-features
+
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
     runs-on: ubuntu-latest
+    needs: commit_list
     # we use a matrix here just because env can't be used in job names
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
+      fail-fast: false
       matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
         msrv: ["1.79"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
@@ -147,6 +219,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ matrix.commit }}
       - name: Install ${{ matrix.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
Instead of only running the top-most commit through our PR gates, let's make sure to check each commit in isolation, this will help us catch accidental situations where build warnings and errors introduced in a previous commit make their way into the main branch.