### PR TITLE
Add clippy_flags to clippy checker

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,6 +98,7 @@ jobs:
         uses: giraffate/clippy-action@v1
         with:
           reporter: 'github-pr-check'
+          clippy_flags: -- -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # Enable once we have a released crate

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -10,7 +10,7 @@ use embassy_hal_internal::{impl_peripheral, into_ref, Peripheral, PeripheralRef}
 use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::interrupt::typelevel::Binding;
-use crate::iopctl::*;
+use crate::iopctl::{DriveMode, DriveStrength, Function, IopctlPin, Polarity, Pull, SlewRate};
 use crate::pac::adc0;
 use crate::{interrupt, peripherals};
 

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -26,6 +26,7 @@ pub struct Config {
 
 impl Config {
     /// Create a new CRC config.
+    #[must_use]
     pub fn new(
         polynomial: Polynomial,
         bit_order_input_reverse: bool,
@@ -53,7 +54,7 @@ impl Default for Config {
             input_complement: false,
             bit_order_crc_reverse: false,
             crc_complement: false,
-            seed: 0xffffffff,
+            seed: 0xffff_ffff,
         }
     }
 }

--- a/src/flexcomm.rs
+++ b/src/flexcomm.rs
@@ -5,19 +5,19 @@ use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::{interrupt, pac, Peripheral, PeripheralRef};
 
-/// alias for fc0::Registers, as layout is the same across all FCn
+/// alias for `fc0::Registers`, as layout is the same across all `FCn`
 pub type FlexcommRegisters = pac::flexcomm0::RegisterBlock;
 
-/// alias for i2c0::Registers, as layout is the same across all FCn
+/// alias for `i2c0::Registers`, as layout is the same across all `FCn`
 pub type I2cRegisters = pac::i2c0::RegisterBlock;
 
-/// alias for spi0::Registers, as layout is the same across all FCn
+/// alias for `spi0::Registers`, as layout is the same across all `FCn`
 pub type SpiRegisters = pac::spi0::RegisterBlock;
 
-/// alias for i2s0::Registers, as layout is the same across all FCn
+/// alias for `i2s0::Registers`, as layout is the same across all `FCn`
 pub type I2sRegisters = pac::i2s0::RegisterBlock;
 
-/// alias for usart0::Registers, as layout is the same across all FCn
+/// alias for `usart0::Registers`, as layout is the same across all `FCn`
 pub type UsartRegisters = pac::usart0::RegisterBlock;
 
 const FC_COUNT: usize = 8;
@@ -33,20 +33,20 @@ pub enum Clock {
     /// FFRO
     Ffro,
 
-    /// AUDIO_PLL
+    /// `AUDIO_PLL`
     AudioPll,
 
     /// MASTER
     Master,
 
-    /// FCn_FRG
+    /// `FCn_FRG`
     FcnFrg,
 
     /// disabled
     None,
 }
 
-/// what mode to configure this FCn to
+/// what mode to configure this `FCn` to
 pub enum Mode {
     /// i2c operation
     I2c,
@@ -77,7 +77,7 @@ mod sealed {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
-    /// feature not present on FCn (such as no SPI or I2S support)
+    /// feature not present on `FCn` (such as no SPI or I2S support)
     FeatureNotPresent,
 }
 
@@ -181,14 +181,14 @@ impl<'p, F: SpiPeripheral> SpiBus<'p, F> {
 #[allow(private_bounds)]
 pub(crate) trait I2sPeripheral: FlexcommLowLevel {}
 
-/// Flexcomm configured for I2sTx usage
+/// Flexcomm configured for `I2sTx` usage
 #[allow(private_bounds)]
 pub struct I2sTransmit<'p, F: I2sPeripheral> {
     _fc: PeripheralRef<'p, F>,
 }
 #[allow(private_bounds)]
 impl<'p, F: I2sPeripheral> I2sTransmit<'p, F> {
-    /// use Flexcomm fc as an I2sTx Bus
+    /// use Flexcomm fc as an `I2sTx` Bus
     pub fn new(fc: impl I2sPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
         F::enable(clk);
         F::set_mode(Mode::I2sTx)?;
@@ -201,14 +201,14 @@ impl<'p, F: I2sPeripheral> I2sTransmit<'p, F> {
     }
 }
 
-/// Flexcomm configured for I2sRx usage
+/// Flexcomm configured for `I2sRx` usage
 #[allow(private_bounds)]
 pub struct I2sReceive<'p, F: I2sPeripheral> {
     _fc: PeripheralRef<'p, F>,
 }
 #[allow(private_bounds)]
 impl<'p, F: I2sPeripheral> I2sReceive<'p, F> {
-    /// use Flexcomm fc as an I2sRx Bus
+    /// use Flexcomm fc as an `I2sRx` Bus
     pub fn new(fc: impl I2sPeripheral<P = F> + 'p, clk: Clock) -> Result<Self> {
         F::enable(clk);
         F::set_mode(Mode::I2sRx)?;
@@ -221,7 +221,7 @@ impl<'p, F: I2sPeripheral> I2sReceive<'p, F> {
     }
 }
 
-/// internal shared USARt peripheral operations
+/// internal shared `USARt` peripheral operations
 #[allow(private_bounds)]
 pub(crate) trait UsartPeripheral: FlexcommLowLevel {}
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -208,11 +208,13 @@ impl<S: Sense> Flex<'_, S> {
     }
 
     /// Is the output level high?
+    #[must_use]
     pub fn is_set_high(&self) -> bool {
         !self.is_set_low()
     }
 
     /// Is the output level low?
+    #[must_use]
     pub fn is_set_low(&self) -> bool {
         (self.pin.block().set(self.pin.port()).read().setp().bits() & (1 << self.pin.pin())) == 0
     }
@@ -261,16 +263,19 @@ impl<'d> Flex<'d, SenseEnabled> {
     }
 
     /// Is high?
+    #[must_use]
     pub fn is_high(&self) -> bool {
         !self.is_low()
     }
 
     /// Is low?
+    #[must_use]
     pub fn is_low(&self) -> bool {
         self.pin.block().b(self.pin.port()).b_(self.pin.pin()).read() == 0
     }
 
     /// Current level
+    #[must_use]
     pub fn get_level(&self) -> Level {
         self.is_high().into()
     }
@@ -312,6 +317,7 @@ impl<'d> Flex<'d, SenseEnabled> {
     /// Return a new Flex pin instance with level sensing disabled.
     ///
     /// Consumes less power than a flex pin with sensing enabled.
+    #[must_use]
     pub fn disable_sensing(self) -> Flex<'d, SenseDisabled> {
         // Cloning the pin is ok since we consume self immediately
         let new_pin = unsafe { self.pin.clone_unchecked() };
@@ -336,6 +342,7 @@ impl<'d> Flex<'d, SenseDisabled> {
     }
 
     /// Return a new Flex pin instance with level sensing enabled.
+    #[must_use]
     pub fn enable_sensing(self) -> Flex<'d, SenseEnabled> {
         // Cloning the pin is ok since we consume self immediately
         let new_pin = unsafe { self.pin.clone_unchecked() };
@@ -358,16 +365,19 @@ impl<'d> Input<'d> {
     }
 
     /// Is high?
+    #[must_use]
     pub fn is_high(&self) -> bool {
         self.pin.is_high()
     }
 
     /// Is low?
+    #[must_use]
     pub fn is_low(&self) -> bool {
         self.pin.is_low()
     }
 
     /// Input level
+    #[must_use]
     pub fn get_level(&self) -> Level {
         self.pin.get_level()
     }
@@ -515,11 +525,13 @@ impl<'d> Output<'d> {
     }
 
     /// Is set high?
+    #[must_use]
     pub fn is_set_high(&self) -> bool {
         self.pin.is_set_high()
     }
 
     /// Is set low?
+    #[must_use]
     pub fn is_set_low(&self) -> bool {
         self.pin.is_set_low()
     }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -32,6 +32,7 @@ pub struct Address(u8);
 
 impl Address {
     /// Construct an address type
+    #[must_use]
     pub const fn new(addr: u8) -> Option<Self> {
         match addr {
             0x08..=0x77 => Some(Self(addr)),
@@ -40,11 +41,13 @@ impl Address {
     }
 
     /// interpret address as a read command
+    #[must_use]
     pub fn read(&self) -> u8 {
         (self.0 << 1) | 1
     }
 
     /// interpret address as a write command
+    #[must_use]
     pub fn write(&self) -> u8 {
         self.0 << 1
     }
@@ -151,7 +154,7 @@ pub struct Async;
 impl Sealed for Async {}
 impl Mode for Async {}
 
-/// use FCn as I2C Master controller
+/// use `FCn` as I2C Master controller
 pub struct I2cMaster<'a, FC: Instance, M: Mode, D: dma::Instance> {
     bus: crate::flexcomm::I2cBus<'a, FC>,
     timeout: TimeoutSettings,
@@ -161,7 +164,7 @@ pub struct I2cMaster<'a, FC: Instance, M: Mode, D: dma::Instance> {
     dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
 }
 
-/// use FCn as I2C Slave controller
+/// use `FCn` as I2C Slave controller
 pub struct I2cSlave<'a, FC: Instance, M: Mode> {
     bus: crate::flexcomm::I2cBus<'a, FC>,
     _phantom: PhantomData<M>,
@@ -304,7 +307,7 @@ impl<'a, FC: Instance, D: dma::Instance> I2cMaster<'a, FC, Blocking, D> {
 
         i2cregs.mstdat().write(|w|
             // SAFETY: only unsafe due to .bits usage
-            unsafe { w.data().bits(address << 1 | if is_read {0x01} else {0x00}) });
+            unsafe { w.data().bits(address << 1 | u8::from(is_read)) });
 
         i2cregs.mstctl().write(|w| w.mststart().set_bit());
 
@@ -362,7 +365,7 @@ impl<'a, FC: Instance, D: dma::Instance> I2cMaster<'a, FC, Blocking, D> {
 
         self.start(address, false)?;
 
-        for byte in write.iter() {
+        for byte in write {
             i2cregs.mstdat().write(|w|
                 // SAFETY: unsafe only due to .bits usage
                 unsafe { w.data().bits(*byte) });
@@ -438,7 +441,7 @@ impl<'a, FC: Instance, D: dma::Instance> I2cMaster<'a, FC, Async, D> {
 
         i2cregs.mstdat().write(|w|
             // SAFETY: only unsafe due to .bits usage
-            unsafe { w.data().bits(address << 1 | if is_read {0x01} else {0x00}) });
+            unsafe { w.data().bits(address << 1 | u8::from(is_read)) });
 
         i2cregs.mstctl().write(|w| w.mststart().set_bit());
 

--- a/src/iopctl.rs
+++ b/src/iopctl.rs
@@ -116,7 +116,7 @@ pub trait IopctlPin: SealedPin {
 
     /// Enables either a pull-up or pull-down resistor on a pin.
     ///
-    /// Setting this to [Pull::None] will disable the resistor.
+    /// Setting this to [`Pull::None`] will disable the resistor.
     fn set_pull(&self, pull: Pull) -> &Self;
 
     /// Enables the input buffer of a pin.
@@ -140,19 +140,19 @@ pub trait IopctlPin: SealedPin {
 
     /// Sets the output drive strength of a pin.
     ///
-    /// A drive strength of [DriveStrength::Full] has twice the
-    /// high and low drive capability of the [DriveStrength::Normal] setting.
+    /// A drive strength of [`DriveStrength::Full`] has twice the
+    /// high and low drive capability of the [`DriveStrength::Normal`] setting.
     fn set_drive_strength(&self, strength: DriveStrength) -> &Self;
 
     /// Enables the analog multiplexer of a pin.
     ///
     /// This must be called to allow analog functionalities of a pin.
     ///
-    /// To protect the analog input, [IopctlPin::set_function] should be
-    /// called with [Function::F0] to disable digital functions.
+    /// To protect the analog input, [`IopctlPin::set_function`] should be
+    /// called with [`Function::F0`] to disable digital functions.
     ///
-    /// Additionally, [IopctlPin::disable_input_buffer] and [IopctlPin::set_pull]
-    /// with [Pull::None] should be called.
+    /// Additionally, [`IopctlPin::disable_input_buffer`] and [`IopctlPin::set_pull`]
+    /// with [`Pull::None`] should be called.
     fn enable_analog_multiplex(&self) -> &Self;
 
     /// Disables the analog multiplexer of a pin.
@@ -160,7 +160,7 @@ pub trait IopctlPin: SealedPin {
 
     /// Sets the ouput drive mode of a pin.
     ///
-    /// A pin configured as [DriveMode::OpenDrain] actually operates in
+    /// A pin configured as [`DriveMode::OpenDrain`] actually operates in
     /// a "pseudo" open-drain mode which is somewhat different than true open-drain.
     ///
     /// See Section 7.4.2.7 of reference manual.
@@ -168,7 +168,7 @@ pub trait IopctlPin: SealedPin {
 
     /// Sets the polarity of an input pin.
     ///
-    /// Setting this to [Polarity::ActiveLow] will invert
+    /// Setting this to [`Polarity::ActiveLow`] will invert
     /// the input signal.
     fn set_input_polarity(&self, polarity: Polarity) -> &Self;
 
@@ -193,13 +193,14 @@ impl AnyPin {
     /// # Safety
     ///
     /// The caller MUST ensure valid port and pin numbers are provided,
-    /// and that multiple instances of [AnyPin] with the same port
+    /// and that multiple instances of [`AnyPin`] with the same port
     /// and pin combination are not being used simultaneously.
     ///
     /// Failure to uphold these requirements will result in undefined behavior.
     ///
     /// See Table 297 in reference manual for a list of valid
     /// pin and port number combinations.
+    #[must_use]
     pub unsafe fn new(port: u8, pin: u8) -> Self {
         // Calculates the offset from the beginning of the IOPCTL register block
         // address to the register address representing the pin.
@@ -208,7 +209,7 @@ impl AnyPin {
         let offset = ((port as usize) << 7) + ((pin as usize) << 2);
 
         // SAFETY: This is safe assuming the caller of this function satisfies the safety requirements above.
-        let reg = unsafe { &*(Iopctl::ptr().byte_offset(offset as isize) as *const _) };
+        let reg = unsafe { &*Iopctl::ptr().byte_offset(offset as isize).cast() };
         Self {
             pin_port: port * 32 + pin,
             reg,
@@ -216,6 +217,7 @@ impl AnyPin {
     }
 
     /// Returns the pin's port and pin combination.
+    #[must_use]
     pub fn pin_port(&self) -> usize {
         self.pin_port as usize
     }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -29,32 +29,32 @@ use embassy_hal_internal::{Peripheral, PeripheralRef};
 /// include pac definitions for instancing
 use mimxrt685s_pac as pac; // TODO: generalize for other chipsets
 
-/// clock source indicator for selecting while powering on the SCTimer
+/// clock source indicator for selecting while powering on the `SCTimer`
 #[derive(Copy, Clone, Debug)]
 pub enum SCTClockSource {
     /// main clock
     Main,
 
-    /// main PLL clock (main_pll_clk)
+    /// main PLL clock (`main_pll_clk`)
     MainPLL,
 
-    /// aux0_pll_clk
+    /// `aux0_pll_clk`
     AUX0PLL,
 
-    /// 48/60m_irc
+    /// `48/60m_irc`
     FFRO,
 
-    /// aux1_pll_clk
+    /// `aux1_pll_clk`
     AUX1PLL,
 
-    /// audio_pll_clk
+    /// `audio_pll_clk`
     AudioPLL,
 
     /// lowest power selection
     None,
 }
 
-/// SCTimer based PWM Interface Constraints
+/// `SCTimer` based PWM Interface Constraints
 #[derive(Copy, Clone, Debug)]
 pub enum Channel {
     /// Channel 0
@@ -95,23 +95,23 @@ static CHANNELS: [Channel; 10] = [
 
 impl Channel {
     fn bit(&self) -> u32 {
-        use Channel::*;
+        use Channel::{Ch0, Ch1, Ch2, Ch3, Ch4, Ch5, Ch6, Ch7, Ch8, Ch9};
         match self {
             Ch0 => 0b1,
             Ch1 => 0b10,
             Ch2 => 0b100,
             Ch3 => 0b1000,
             Ch4 => 0b10000,
-            Ch5 => 0b100000,
-            Ch6 => 0b1000000,
-            Ch7 => 0b10000000,
-            Ch8 => 0b100000000,
-            Ch9 => 0b1000000000,
+            Ch5 => 0b10_0000,
+            Ch6 => 0b100_0000,
+            Ch7 => 0b1000_0000,
+            Ch8 => 0b1_0000_0000,
+            Ch9 => 0b10_0000_0000,
         }
     }
 
     fn number(&self) -> usize {
-        use Channel::*;
+        use Channel::{Ch0, Ch1, Ch2, Ch3, Ch4, Ch5, Ch6, Ch7, Ch8, Ch9};
         match self {
             Ch0 => 0,
             Ch1 => 1,
@@ -156,17 +156,19 @@ impl CentiPercent {
     /// 00.00%
     pub const MIN: CentiPercent = CentiPercent(0, 0);
 
-    /// Convert from this CentiPercent into a u32 (X) / max
+    /// Convert from this `CentiPercent` into a u32 (X) / max
+    #[must_use]
     pub fn as_scaled(&self, max: u32) -> u32 {
-        ((self.0 as u64) * (max as u64) / 100 + (self.1 as u64) * (max as u64) / 10_000) as u32
+        (u64::from(self.0) * u64::from(max) / 100 + u64::from(self.1) * u64::from(max) / 10_000) as u32
     }
 
-    /// Convert from a u32 ratio (value / max) to a CentiPercent (PCT.pp%)
+    /// Convert from a u32 ratio (value / max) to a `CentiPercent` (PCT.pp%)
+    #[must_use]
     pub fn from_scaled(value: u32, max: u32) -> CentiPercent {
         // extract percentage
-        let pct = (((value as u64) * 100) / (max as u64)) as u8;
-        let dec = ((value as u64) * 10_000) / (max as u64);
-        let dec = (dec - (pct as u64) * 100) as u8;
+        let pct = ((u64::from(value) * 100) / u64::from(max)) as u8;
+        let dec = (u64::from(value) * 10_000) / u64::from(max);
+        let dec = (dec - u64::from(pct) * 100) as u8;
 
         CentiPercent(pct, dec)
     }
@@ -182,7 +184,7 @@ impl From<MicroSeconds> for Hertz {
 // only allow specified instances to SCTPwm construct
 impl sealed::SCTimer for crate::peripherals::SCT0 {
     fn set_clock_source(clock: self::SCTClockSource) {
-        use SCTClockSource::*;
+        use SCTClockSource::{AudioPLL, Main, MainPLL, None, AUX0PLL, AUX1PLL, FFRO};
 
         // SAFETY: safe so long as executed from single executor context or during initialization only
         let clkctl0 = unsafe { pac::Clkctl0::steal() };
@@ -219,7 +221,7 @@ impl sealed::SCTimer for crate::peripherals::SCT0 {
     }
 
     fn get_clock_rate(clock: self::SCTClockSource) -> Hertz {
-        use SCTClockSource::*;
+        use SCTClockSource::{AudioPLL, Main, MainPLL, None, AUX0PLL, AUX1PLL, FFRO};
 
         // TODO - fix these
         match clock {
@@ -296,7 +298,7 @@ impl sealed::SCTimer for crate::peripherals::SCT0 {
     }
 }
 
-/// Basic PWM Object, Consumes a SCTimer peripheral hardware instance on construction
+/// Basic PWM Object, Consumes a `SCTimer` peripheral hardware instance on construction
 pub struct SCTPwm<'d, T: sealed::SCTimer> {
     _p: PeripheralRef<'d, T>,
     period: MicroSeconds,
@@ -305,7 +307,7 @@ pub struct SCTPwm<'d, T: sealed::SCTimer> {
 }
 
 impl<'d, T: sealed::SCTimer> SCTPwm<'d, T> {
-    /// Take the SCTimer instance supplied and use it as a simple PWM driver. Function returns constructed Pwm instance.
+    /// Take the `SCTimer` instance supplied and use it as a simple PWM driver. Function returns constructed Pwm instance.
     pub fn new(sct: impl Peripheral<P = T> + 'd, period: MicroSeconds, clock: SCTClockSource) -> Self {
         // requested period must be possible with configured clock selection (within bounds of u8 divisor)!
 
@@ -469,7 +471,7 @@ impl<'d, T: sealed::SCTimer> embedded_hal_02::Pwm for SCTPwm<'d, T> {
     }
 
     fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
-        use Channel::*;
+        use Channel::{Ch0, Ch1, Ch2, Ch3, Ch4, Ch5, Ch6, Ch7, Ch8, Ch9};
         // SAFETY: safe so long as SCTPwm is not used across multiple executors
         let sct0 = unsafe { pac::Sct0::steal() };
 
@@ -500,7 +502,7 @@ impl<'d, T: sealed::SCTimer> embedded_hal_02::Pwm for SCTPwm<'d, T> {
         // SAFETY: safe so long as SCTPwm is not used across multiple executors
         let sct0 = unsafe { pac::Sct0::steal() };
 
-        use Channel::*;
+        use Channel::{Ch0, Ch1, Ch2, Ch3, Ch4, Ch5, Ch6, Ch7, Ch8, Ch9};
 
         match channel {
             Ch0 => sct0.matchrel0().write(|w|

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -145,7 +145,7 @@ impl<'d, T: Instance> Rng<'d, T> {
 
                 // write bytes to chunk
                 for (dest, src) in chunk.iter_mut().zip(entropy.iter()) {
-                    *dest = *src
+                    *dest = *src;
                 }
             }
         }


### PR DESCRIPTION
As an attempt to further raise the quality of the code going in, let's also enable further clippy checks during CI. At the same time, all existing offenders were corrected with `cargo clippy --fix`.