### PR TITLE
Add reference counting to GPIO pins to init/deinit clock control to port

### DIFF
--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -5,7 +5,7 @@ extern crate embassy_imxrt_examples;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt::gpio;
+use embassy_imxrt::{gpio, pac};
 use embassy_time::Timer;
 
 #[embassy_executor::main]
@@ -14,12 +14,24 @@ async fn main(_spawner: Spawner) {
 
     info!("Initializing GPIO");
 
+    let cc1 = unsafe { pac::Clkctl1::steal() };
+
+    assert!(
+        cc1.pscctl1().read().hsgpio0_clk().is_disable_clock(),
+        "GPIO port 0 clock was enabled before any GPIO pins were created!"
+    );
+
     let mut led = gpio::Output::new(
         p.PIO0_26,
         gpio::Level::Low,
         gpio::DriveMode::PushPull,
         gpio::DriveStrength::Normal,
         gpio::SlewRate::Standard,
+    );
+
+    assert!(
+        cc1.pscctl1().read().hsgpio0_clk().is_enable_clock(),
+        "GPIO port 0 clock is still disabled even after a GPIO pin is created!"
     );
 
     loop {


### PR DESCRIPTION
Resolves #61 
GPIO port clocks are now disabled if no pin from that port is active.

`gpio::init()` has been changed to disable all clocks and only explicitly enable the port clock when a gpio pin (Input, Output, Flex) is instantiated.