### PR TITLE
iopctl: rename Polarity to Inverter

### DIFF
--- a/examples/rt685s-evk/src/bin/clocks-blinky.rs
+++ b/examples/rt685s-evk/src/bin/clocks-blinky.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner) {
         .disable_input_buffer()
         .set_drive_mode(embassy_imxrt::gpio::DriveMode::PushPull)
         .set_drive_strength(embassy_imxrt::gpio::DriveStrength::Normal)
-        .set_input_polarity(embassy_imxrt::gpio::Polarity::ActiveHigh)
+        .set_input_inverter(embassy_imxrt::gpio::Inverter::Disabled)
         .set_function(embassy_imxrt::gpio::Function::F7)
         .set_slew_rate(embassy_imxrt::gpio::SlewRate::Standard)
         .set_pull(embassy_imxrt::gpio::Pull::None);

--- a/examples/rt685s-evk/src/bin/gpio-async-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-async-input.rs
@@ -47,7 +47,7 @@ async fn main(spawner: Spawner) {
         gpio::SlewRate::Standard,
     );
 
-    let monitor = gpio::Input::new(p.PIO1_0, gpio::Pull::None, gpio::Polarity::ActiveHigh);
+    let monitor = gpio::Input::new(p.PIO1_0, gpio::Pull::None, gpio::Inverter::Disabled);
 
     let mut ticker = Ticker::every(Duration::from_millis(100));
 

--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -42,7 +42,7 @@ async fn main(_spawner: Spawner) {
     assert!(flex.is_low());
 
     // set pin direction to output with reverse polarity
-    flex.set_as_input(gpio::Pull::None, gpio::Polarity::ActiveLow);
+    flex.set_as_input(gpio::Pull::None, gpio::Inverter::Enabled);
 
     // check pin level is high
     assert!(flex.is_high());

--- a/examples/rt685s-evk/src/bin/gpio-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-input.rs
@@ -15,7 +15,7 @@ async fn main(_spawner: Spawner) {
     info!("Initializing GPIO");
     unsafe { gpio::init() };
 
-    let monitor = gpio::Input::new(p.PIO1_0, gpio::Pull::None, gpio::Polarity::ActiveHigh);
+    let monitor = gpio::Input::new(p.PIO1_0, gpio::Pull::None, gpio::Inverter::Disabled);
 
     loop {
         info!("Pin level is {}", monitor.get_level());

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -79,7 +79,7 @@ async fn main(_spawner: Spawner) {
     // Pseudo Output Drain is disabled
     // Input function is not inverted
     info!("Configuring GPIO1_5 as input");
-    let _isr_pin = Input::new(p.PIO1_5, Pull::Down, Polarity::ActiveHigh);
+    let _isr_pin = Input::new(p.PIO1_5, Pull::Down, Inverter::Disabled);
 
     info!("i2c example - I2c::new");
     let mut i2c = i2c::I2cMaster::new_async(

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -80,7 +80,7 @@ async fn main(_spawner: Spawner) {
     // Pseudo Output Drain is disabled
     // Input function is not inverted
     info!("Configuring GPIO1_5 as input");
-    let _isr_pin = Input::new(p.PIO1_5, Pull::Down, Polarity::ActiveHigh);
+    let _isr_pin = Input::new(p.PIO1_5, Pull::Down, Inverter::Disabled);
 
     info!("i2c example - I2c::new");
     let mut i2c = i2c::I2cMaster::new_blocking(

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -10,7 +10,7 @@ use embassy_hal_internal::{impl_peripheral, into_ref, Peripheral, PeripheralRef}
 use embassy_sync::waitqueue::AtomicWaker;
 
 use crate::interrupt::typelevel::Binding;
-use crate::iopctl::{DriveMode, DriveStrength, Function, IopctlPin, Polarity, Pull, SlewRate};
+use crate::iopctl::{DriveMode, DriveStrength, Function, Inverter, IopctlPin, Pull, SlewRate};
 use crate::pac::adc0;
 use crate::{interrupt, peripherals};
 
@@ -422,7 +422,7 @@ macro_rules! impl_pin {
                     .set_drive_strength(DriveStrength::Normal)
                     .enable_analog_multiplex()
                     .set_drive_mode(DriveMode::PushPull)
-                    .set_input_polarity(Polarity::ActiveHigh);
+                    .set_input_inverter(Inverter::Disabled);
 
                 AdcChannel {
                     ch: crate::pac::adc0::cmdl::Adch::$ch,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -12,7 +12,7 @@ use sealed::Sealed;
 
 use crate::clocks::enable_and_reset;
 use crate::iopctl::IopctlPin;
-pub use crate::iopctl::{AnyPin, DriveMode, DriveStrength, Function, Polarity, Pull, SlewRate};
+pub use crate::iopctl::{AnyPin, DriveMode, DriveStrength, Function, Inverter, Pull, SlewRate};
 use crate::{interrupt, into_ref, peripherals, Peripheral, PeripheralRef};
 
 // This should be unique per IMXRT package
@@ -252,8 +252,8 @@ impl<'d> Flex<'d, SenseEnabled> {
     }
 
     /// Converts pin to input pin
-    pub fn set_as_input(&mut self, pull: Pull, polarity: Polarity) {
-        self.pin.set_pull(pull).set_input_polarity(polarity);
+    pub fn set_as_input(&mut self, pull: Pull, inverter: Inverter) {
+        self.pin.set_pull(pull).set_input_inverter(inverter);
 
         self.pin.block().dirclr(self.pin.port()).write(|w|
                     // SAFETY: Writing a 0 to bits in this register has no effect,
@@ -358,9 +358,9 @@ pub struct Input<'d> {
 
 impl<'d> Input<'d> {
     /// New input pin
-    pub fn new(pin: impl Peripheral<P = impl GpioPin> + 'd, pull: Pull, polarity: Polarity) -> Self {
+    pub fn new(pin: impl Peripheral<P = impl GpioPin> + 'd, pull: Pull, inverter: Inverter) -> Self {
         let mut pin = Flex::<SenseEnabled>::new(pin);
-        pin.set_as_input(pull, polarity);
+        pin.set_as_input(pull, inverter);
         Self { pin }
     }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1014,7 +1014,7 @@ macro_rules! impl_scl {
                     .set_slew_rate(crate::gpio::SlewRate::Standard)
                     .set_drive_strength(crate::gpio::DriveStrength::Normal)
                     .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
-                    .set_input_polarity(crate::gpio::Polarity::ActiveHigh)
+                    .set_input_inverter(crate::gpio::Inverter::Disabled)
                     .enable_input_buffer()
                     .set_function(crate::iopctl::Function::$fn);
             }
@@ -1030,7 +1030,7 @@ macro_rules! impl_sda {
                     .set_slew_rate(crate::gpio::SlewRate::Standard)
                     .set_drive_strength(crate::gpio::DriveStrength::Normal)
                     .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
-                    .set_input_polarity(crate::gpio::Polarity::ActiveHigh)
+                    .set_input_inverter(crate::gpio::Inverter::Disabled)
                     .enable_input_buffer()
                     .set_function(crate::iopctl::Function::$fn);
             }


### PR DESCRIPTION
By renaming Polarity to Inverter we make it clearer for the user of the HAL what this is all about. We're not really choosing a polarity (active low vs active high) we are enabling or disabling an inverter on the input pin.

Fixes #156