### PR TITLE
Make use of the github context while fetching commit list

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "id0=$GITHUB_SHA" > $GITHUB_OUTPUT
         echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- https://github.com/pop-project/embassy-imxrt/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
+        sed -n 's,^id[0-9]\+=\(.*\),- ${{ github.repositoryUrl }}/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
 
     - name: Get commit list (PR)
       id: get_commit_list_pr
@@ -46,7 +46,7 @@ jobs:
         git rev-list --reverse refs/remotes/origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | awk '{ print "id" NR "=" $1 }' > $GITHUB_OUTPUT
         git diff --quiet ${{ github.event.pull_request.head.sha }} ${{ github.sha }} || echo "id0=$GITHUB_SHA" >> $GITHUB_OUTPUT
         echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- https://github.com/pop-project/embassy-imxrt/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
+        sed -n 's,^id[0-9]\+=\(.*\),- ${{ github.repositoryUrl }}/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
 
     outputs:
       commits: ${{ toJSON(steps.*.outputs.*) }}


### PR DESCRIPTION
This is a simple cleanup that makes this workflow easier to reuse by not having the repository url hardcoded in the yaml file.