### PR TITLE
I2c master fixes

### DIFF
--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -87,7 +87,6 @@ async fn main(_spawner: Spawner) {
         p.FLEXCOMM2,
         p.PIO0_18,
         p.PIO0_17,
-        Pull::Down,
         i2c::master::Speed::Standard,
         p.DMA0_CH5,
     )

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -88,7 +88,6 @@ async fn main(_spawner: Spawner) {
         p.FLEXCOMM2,
         p.PIO0_18,
         p.PIO0_17,
-        Pull::Down,
         i2c::master::Speed::Standard,
         p.DMA0_CH5,
     )

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -34,12 +34,11 @@ impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cMaster<'a, FC, M, D> {
         scl: impl SclPin<FC> + 'a,
         sda: impl SdaPin<FC> + 'a,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        pull: crate::iopctl::Pull,
         speed: Speed,
         dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
     ) -> Result<Self> {
-        sda.as_sda(pull);
-        scl.as_scl(pull);
+        sda.as_sda();
+        scl.as_scl();
 
         // this check should be redundant with T::set_mode()? above
 
@@ -103,14 +102,13 @@ impl<'a, FC: Instance, D: dma::Instance> I2cMaster<'a, FC, Blocking, D> {
         scl: impl SclPin<FC> + 'a,
         sda: impl SdaPin<FC> + 'a,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        pull: crate::iopctl::Pull,
         speed: Speed,
         _dma_ch: impl Peripheral<P = D> + 'a,
     ) -> Result<Self> {
         // TODO - clock integration
         let clock = crate::flexcomm::Clock::Sfro;
         let bus: crate::flexcomm::I2cBus<'_, FC> = crate::flexcomm::I2cBus::new_blocking(fc, clock)?;
-        let this = Self::new_inner(bus, scl, sda, pull, speed, None)?;
+        let this = Self::new_inner(bus, scl, sda, speed, None)?;
 
         Ok(this)
     }
@@ -229,7 +227,6 @@ impl<'a, FC: Instance, D: dma::Instance> I2cMaster<'a, FC, Async, D> {
         scl: impl SclPin<FC> + 'a,
         sda: impl SdaPin<FC> + 'a,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        pull: crate::iopctl::Pull,
         speed: Speed,
         dma_ch: impl Peripheral<P = D> + 'a,
     ) -> Result<Self> {
@@ -237,7 +234,7 @@ impl<'a, FC: Instance, D: dma::Instance> I2cMaster<'a, FC, Async, D> {
         let clock = crate::flexcomm::Clock::Sfro;
         let bus: crate::flexcomm::I2cBus<'_, FC> = crate::flexcomm::I2cBus::new_async(fc, clock)?;
         let ch = dma::Dma::reserve_channel(dma_ch);
-        let this = Self::new_inner(bus, scl, sda, pull, speed, Some(ch))?;
+        let this = Self::new_inner(bus, scl, sda, speed, Some(ch))?;
 
         Ok(this)
     }

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -97,13 +97,13 @@ impl Instance for crate::peripherals::FLEXCOMM7 {}
 /// io configuration trait for easier configuration
 pub trait SclPin<Instance>: Pin + sealed::Sealed + crate::Peripheral {
     /// convert the pin to appropriate function for SCL usage
-    fn as_scl(&self, pull: crate::iopctl::Pull);
+    fn as_scl(&self);
 }
 
 /// io configuration trait for easier configuration
 pub trait SdaPin<Instance>: Pin + sealed::Sealed + crate::Peripheral {
     /// convert the pin to appropriate function for SDA usage
-    fn as_sda(&self, pull: crate::iopctl::Pull);
+    fn as_sda(&self);
 }
 
 /// Driver mode.
@@ -124,15 +124,16 @@ impl Mode for Async {}
 macro_rules! impl_scl {
     ($piom_n:ident, $fn:ident, $fcn:ident) => {
         impl SclPin<crate::peripherals::$fcn> for crate::peripherals::$piom_n {
-            fn as_scl(&self, pull: crate::iopctl::Pull) {
-                // UM11147 table 299 pg 262+
-                self.set_pull(pull)
-                    .set_slew_rate(crate::gpio::SlewRate::Standard)
-                    .set_drive_strength(crate::gpio::DriveStrength::Normal)
-                    .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
-                    .set_input_inverter(crate::gpio::Inverter::Disabled)
+            fn as_scl(&self) {
+                // UM11147 table 556 pg 550
+                self.set_function(crate::iopctl::Function::$fn)
+                    .set_pull(crate::iopctl::Pull::None)
                     .enable_input_buffer()
-                    .set_function(crate::iopctl::Function::$fn);
+                    .set_slew_rate(crate::gpio::SlewRate::Slow)
+                    .set_drive_strength(crate::gpio::DriveStrength::Full)
+                    .disable_analog_multiplex()
+                    .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
+                    .set_input_inverter(crate::gpio::Inverter::Disabled);
             }
         }
     };
@@ -140,15 +141,16 @@ macro_rules! impl_scl {
 macro_rules! impl_sda {
     ($piom_n:ident, $fn:ident, $fcn:ident) => {
         impl SdaPin<crate::peripherals::$fcn> for crate::peripherals::$piom_n {
-            fn as_sda(&self, pull: crate::iopctl::Pull) {
-                // UM11147 table 299 pg 262+
-                self.set_pull(pull)
-                    .set_slew_rate(crate::gpio::SlewRate::Standard)
-                    .set_drive_strength(crate::gpio::DriveStrength::Normal)
-                    .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
-                    .set_input_inverter(crate::gpio::Inverter::Disabled)
+            fn as_sda(&self) {
+                // UM11147 table 556 pg 550
+                self.set_function(crate::iopctl::Function::$fn)
+                    .set_pull(crate::iopctl::Pull::None)
                     .enable_input_buffer()
-                    .set_function(crate::iopctl::Function::$fn);
+                    .set_slew_rate(crate::gpio::SlewRate::Slow)
+                    .set_drive_strength(crate::gpio::DriveStrength::Full)
+                    .disable_analog_multiplex()
+                    .set_drive_mode(crate::gpio::DriveMode::OpenDrain)
+                    .set_input_inverter(crate::gpio::Inverter::Disabled);
             }
         }
     };

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -54,12 +54,11 @@ impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cSlave<'a, FC, M, D> {
         scl: impl SclPin<FC>,
         sda: impl SdaPin<FC>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        pull: crate::iopctl::Pull,
         address: Address,
         dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
     ) -> Result<Self> {
-        sda.as_sda(pull);
-        scl.as_scl(pull);
+        sda.as_sda();
+        scl.as_scl();
 
         // this check should be redundant with T::set_mode()? above
         let i2c = bus.i2c();
@@ -103,7 +102,6 @@ impl<'a, FC: Instance, D: dma::Instance> I2cSlave<'a, FC, Blocking, D> {
         scl: impl SclPin<FC>,
         sda: impl SdaPin<FC>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        pull: crate::iopctl::Pull,
         address: Address,
         _dma_ch: impl Peripheral<P = D> + 'a,
     ) -> Result<Self> {
@@ -111,7 +109,7 @@ impl<'a, FC: Instance, D: dma::Instance> I2cSlave<'a, FC, Blocking, D> {
         let clock = crate::flexcomm::Clock::Sfro;
         let bus = crate::flexcomm::I2cBus::new_blocking(fc, clock)?;
 
-        Self::new_inner(bus, scl, sda, pull, address, None)
+        Self::new_inner(bus, scl, sda, address, None)
     }
 
     fn poll(&self) -> Result<()> {
@@ -143,7 +141,6 @@ impl<'a, FC: Instance, D: dma::Instance> I2cSlave<'a, FC, Async, D> {
         scl: impl SclPin<FC>,
         sda: impl SdaPin<FC>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        pull: crate::iopctl::Pull,
         address: Address,
         dma_ch: impl Peripheral<P = D> + 'a,
     ) -> Result<Self> {
@@ -151,7 +148,7 @@ impl<'a, FC: Instance, D: dma::Instance> I2cSlave<'a, FC, Async, D> {
         let clock = crate::flexcomm::Clock::Sfro;
         let bus = crate::flexcomm::I2cBus::new_async(fc, clock)?;
         let ch = dma::Dma::reserve_channel(dma_ch);
-        Self::new_inner(bus, scl, sda, pull, address, Some(ch))
+        Self::new_inner(bus, scl, sda, address, Some(ch))
     }
 
     async fn block_until_addressed(&self) -> Result<()> {


### PR DESCRIPTION
A small correction to I2C IOPCTL config settings, and a removal of the need for and `async` constructor.

Depends on #165 