### PR TITLE
remove DMA Instance from DMA and DMA-related structs' typestate

### DIFF
--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -5,7 +5,11 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_imxrt::dma::transfer::TransferOptions;
 use embassy_imxrt::dma::Dma;
-use embassy_imxrt::{bind_interrupts, peripherals, rng};
+use embassy_imxrt::{
+    bind_interrupts,
+    peripherals::{self, *},
+    rng,
+};
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
@@ -14,7 +18,7 @@ bind_interrupts!(struct Irqs {
 
 macro_rules! test_dma_channel {
     ($peripherals: expr, $rng: expr, $instance: ident, $number: expr) => {
-        let ch = Dma::reserve_channel($peripherals.$instance);
+        let ch = Dma::reserve_channel::<$instance>($peripherals.$instance);
         let mut srcbuf = [0u8; 10];
         let mut dstbuf = [1u8; 10];
 

--- a/src/dma/transfer.rs
+++ b/src/dma/transfer.rs
@@ -1,6 +1,5 @@
 //! DMA transfer management
 
-use super::Instance;
 use crate::dma::channel::{Channel, Request};
 
 /// DMA transfer options
@@ -82,14 +81,14 @@ pub enum Direction {
 
 /// DMA transfer
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Transfer<'d, T: Instance> {
-    _inner: &'d Channel<'d, T>,
+pub struct Transfer<'d> {
+    _inner: &'d Channel<'d>,
 }
 
-impl<'d, T: Instance> Transfer<'d, T> {
+impl<'d> Transfer<'d> {
     /// Reads from a peripheral register into a memory buffer using DMA
     pub fn new_read(
-        channel: &'d Channel<'d, T>,
+        channel: &'d Channel<'d>,
         request: Request,
         peri_addr: *const u8,
         buf: &'d mut [u8],
@@ -108,7 +107,7 @@ impl<'d, T: Instance> Transfer<'d, T> {
 
     /// Writes a memory buffer into a peripheral register using DMA
     pub fn new_write(
-        channel: &'d Channel<'d, T>,
+        channel: &'d Channel<'d>,
         request: Request,
         buf: &'d [u8],
         peri_addr: *mut u8,
@@ -127,7 +126,7 @@ impl<'d, T: Instance> Transfer<'d, T> {
 
     /// Writes a memory buffer into another memory buffer using DMA
     pub fn new_write_mem(
-        channel: &'d Channel<'d, T>,
+        channel: &'d Channel<'d>,
         request: Request,
         src_buf: &'d [u8],
         dst_buf: &'d mut [u8],
@@ -146,7 +145,7 @@ impl<'d, T: Instance> Transfer<'d, T> {
 
     /// Configures the channel and initiates the DMA transfer
     fn new_inner_transfer(
-        channel: &'d Channel<'d, T>,
+        channel: &'d Channel<'d>,
         _request: Request,
         dir: Direction,
         src_buf: *const u32,

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -25,7 +25,8 @@ pub enum Speed {
 pub struct I2cMaster<'a, FC: Instance, M: Mode, D: dma::Instance> {
     bus: crate::flexcomm::I2cBus<'a, FC>,
     _phantom: PhantomData<M>,
-    dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
+    _phantom2: PhantomData<D>,
+    dma_ch: Option<dma::channel::ChannelAndRequest<'a>>,
 }
 
 impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cMaster<'a, FC, M, D> {
@@ -35,7 +36,7 @@ impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cMaster<'a, FC, M, D> {
         sda: impl SdaPin<FC> + 'a,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
         speed: Speed,
-        dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
+        dma_ch: Option<dma::channel::ChannelAndRequest<'a>>,
     ) -> Result<Self> {
         sda.as_sda();
         scl.as_scl();
@@ -78,6 +79,7 @@ impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cMaster<'a, FC, M, D> {
         Ok(Self {
             bus,
             _phantom: PhantomData,
+            _phantom2: PhantomData,
             dma_ch,
         })
     }

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -44,7 +44,8 @@ impl From<Address> for u8 {
 pub struct I2cSlave<'a, FC: Instance, M: Mode, D: dma::Instance> {
     bus: crate::flexcomm::I2cBus<'a, FC>,
     _phantom: PhantomData<M>,
-    dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
+    _phantom2: PhantomData<D>,
+    dma_ch: Option<dma::channel::ChannelAndRequest<'a>>,
 }
 
 impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cSlave<'a, FC, M, D> {
@@ -55,7 +56,7 @@ impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cSlave<'a, FC, M, D> {
         sda: impl SdaPin<FC>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
         address: Address,
-        dma_ch: Option<dma::channel::ChannelAndRequest<'a, D>>,
+        dma_ch: Option<dma::channel::ChannelAndRequest<'a>>,
     ) -> Result<Self> {
         sda.as_sda();
         scl.as_scl();
@@ -90,6 +91,7 @@ impl<'a, FC: Instance, M: Mode, D: dma::Instance> I2cSlave<'a, FC, M, D> {
         Ok(Self {
             bus,
             _phantom: PhantomData,
+            _phantom2: PhantomData::<D>,
             dma_ch,
         })
     }


### PR DESCRIPTION
This PR removes the D: Instance type from the typestate of DMA, Channel, and Transfer structs. This is a breaking change so the I2C module constructors and the dma-mem example have been updated. The DMA instance and the Flexcomm instance will be removed from the typestate of I2C structs in a later PR.