### PR TITLE
i2c slave async refactor without autoack

### DIFF
--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -3,41 +3,55 @@
 
 extern crate embassy_imxrt_examples;
 
-use defmt::{error, info};
+use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::{
-    slave::{Address, I2cSlave},
+    slave::{Address, Command, I2cSlave, Response},
     Async,
 };
-use embassy_imxrt::iopctl::Pull;
 use embassy_imxrt::pac;
 use embassy_imxrt::peripherals::{DMA0_CH4, FLEXCOMM2};
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
+const BUFLEN: usize = 8;
 
 #[embassy_executor::task]
 async fn slave_service(mut i2c: I2cSlave<'static, FLEXCOMM2, Async, DMA0_CH4>) {
     loop {
-        let magic_code = [0xF0, 0x05, 0xBA, 0x11];
+        let mut buf: [u8; BUFLEN] = [0xAA; BUFLEN];
 
-        let mut cmd_length: [u8; 1] = [0xAA; 1];
-        info!("i2cs example - wait for cmd - read cmd length first");
-        i2c.listen(&mut cmd_length, false).await.unwrap();
-        info!("cmd length = {:02X}", cmd_length);
+        for (i, e) in buf.iter_mut().enumerate() {
+            *e = i as u8;
+        }
 
-        let mut cmd: [u8; 4] = [0xAA; 4];
-        info!("i2cs example - wait for cmd - read the actual cmd");
-        i2c.listen(&mut cmd, true).await.unwrap();
-        info!("cmd length = {:02X}", cmd_length);
-
-        if cmd == [0xDE, 0xAD, 0xBE, 0xEF] {
-            info!("i2cs example - receive init cmd");
-        } else if cmd == [0xDE, 0xCA, 0xFB, 0xAD] {
-            info!("i2cs example - receive magic cmd, writing back magic code to host");
-            i2c.respond(&magic_code).await.unwrap();
-        } else {
-            error!("unexpected cmd = {:02X}", cmd);
-            panic!("i2cs example - unexpected cmd");
+        match i2c.listen().await.unwrap() {
+            Command::Probe => {
+                info!("Probe, nothing to do");
+            }
+            Command::Read => {
+                info!("Read");
+                loop {
+                    match i2c.respond_to_read(&buf).await.unwrap() {
+                        Response::Complete(_) => {
+                            info!("Response complete read with {} bytes", n);
+                            break;
+                        }
+                        Response::Pending(n) => info!("Response to read got {} bytes, more bytes to fill", n),
+                    }
+                }
+            }
+            Command::Write => {
+                info!("Write");
+                loop {
+                    match i2c.respond_to_write(&mut buf).await.unwrap() {
+                        Response::Complete(_) => {
+                            //info!("Response complete write with {} bytes", n);
+                            break;
+                        }
+                        Response::Pending(n) => info!("Response to write got {} bytes, more bytes pending", n),
+                    }
+                }
+            }
         }
     }
 }
@@ -55,15 +69,7 @@ async fn main(spawner: Spawner) {
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5
     //       Test program here: https://github.com/jerrysxie/pi5-i2c-test
     info!("i2cs example - I2c::new");
-    let i2c = I2cSlave::new_async(
-        p.FLEXCOMM2,
-        p.PIO0_18,
-        p.PIO0_17,
-        Pull::Down,
-        SLAVE_ADDR.unwrap(),
-        p.DMA0_CH4,
-    )
-    .unwrap();
+    let i2c = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 
     spawner.must_spawn(slave_service(i2c));
 }

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -9,7 +9,6 @@ use embassy_imxrt::i2c::{
     slave::{Address, I2cSlave},
     Blocking,
 };
-use embassy_imxrt::iopctl::Pull;
 use embassy_imxrt::pac;
 use embassy_imxrt::peripherals::{DMA0_CH4, FLEXCOMM2};
 
@@ -53,15 +52,7 @@ async fn main(spawner: Spawner) {
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5
     //       Test program here: https://github.com/jerrysxie/pi5-i2c-test
     info!("i2cs example - I2c::new");
-    let i2c = I2cSlave::new_blocking(
-        p.FLEXCOMM2,
-        p.PIO0_18,
-        p.PIO0_17,
-        Pull::Down,
-        SLAVE_ADDR.unwrap(),
-        p.DMA0_CH4,
-    )
-    .unwrap();
+    let i2c = I2cSlave::new_blocking(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 
     spawner.must_spawn(slave_service(i2c));
 }

--- a/src/dma/channel.rs
+++ b/src/dma/channel.rs
@@ -54,10 +54,39 @@ impl<'d> ChannelAndRequest<'d> {
         &DMA_WAKERS[self.channel.info.ch_num]
     }
 
-    /// Check whether DMA is busy
+    /// Check whether DMA is active
     pub fn is_active(&self) -> bool {
         let channel = self.channel.info.ch_num;
         self.channel.info.regs.active0().read().act().bits() & (1 << channel) != 0
+    }
+
+    /// Check whether DMA is busy
+    pub fn is_busy(&self) -> bool {
+        let channel = self.channel.info.ch_num;
+        self.channel.info.regs.busy0().read().bsy().bits() & (1 << channel) != 0
+    }
+
+    /// Return DMA remaining transfer count
+    pub fn get_xfer_count(&self) -> u16 {
+        let channel = self.channel.info.ch_num;
+        self.channel
+            .info
+            .regs
+            .channel(channel)
+            .xfercfg()
+            .read()
+            .xfercount()
+            .bits()
+    }
+
+    /// Abort DMA operation
+    pub fn abort(&self) {
+        let channel = self.channel.info.ch_num;
+        self.channel.disable_channel();
+        while self.is_busy() {}
+        self.channel.info.regs.abort0().write(|w|
+                    // SAFETY: unsafe due to .bits usage
+                    unsafe { w.abortctrl().bits(1 << channel) });
     }
 
     async fn poll_transfer_complete(&'d self) {
@@ -172,6 +201,14 @@ impl Channel<'_> {
             .regs
             .enableset0()
             .modify(|_, w| unsafe { w.ena().bits(1 << channel) });
+    }
+
+    /// Disable the DMA channel
+    pub fn disable_channel(&self) {
+        let channel = self.info.ch_num;
+        self.info.regs.enableclr0().write(|w|
+                // SAFETY: unsafe due to .bits usage
+                unsafe { w.clr().bits(1 << channel) });
     }
 
     /// Trigger the DMA channel

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -40,6 +40,27 @@ impl From<Address> for u8 {
     }
 }
 
+/// Command from master
+pub enum Command {
+    /// I2C probe with no data
+    Probe,
+
+    /// I2C Read
+    Read,
+
+    /// I2C Write
+    Write,
+}
+
+/// Result of response functions
+pub enum Response {
+    /// I2C transaction complete with this amount of bytes
+    Complete(usize),
+
+    /// I2C transaction pending wutg this amount of bytes completed so far
+    Pending(usize),
+}
+
 /// use `FCn` as I2C Slave controller
 pub struct I2cSlave<'a, FC: Instance, M: Mode, D: dma::Instance> {
     bus: crate::flexcomm::I2cBus<'a, FC>,
@@ -152,39 +173,6 @@ impl<'a, FC: Instance, D: dma::Instance> I2cSlave<'a, FC, Async, D> {
         let ch = dma::Dma::reserve_channel(dma_ch);
         Self::new_inner(bus, scl, sda, address, Some(ch))
     }
-
-    async fn block_until_addressed(&self) -> Result<()> {
-        let i2c = self.bus.i2c();
-
-        i2c.intenset()
-            .write(|w| w.slvpendingen().set_bit().slvdeselen().set_bit());
-
-        poll_fn(|cx: &mut core::task::Context<'_>| {
-            self.bus.waker().register(cx.waker());
-            if i2c.stat().read().slvpending().bit_is_set() {
-                return Poll::Ready(());
-            }
-
-            if i2c.stat().read().slvdesel().bit_is_set() {
-                i2c.stat().write(|w| w.slvdesel().deselected());
-                return Poll::Ready(());
-            }
-
-            Poll::Pending
-        })
-        .await;
-
-        i2c.intenclr()
-            .write(|w| w.slvpendingclr().set_bit().slvdeselclr().set_bit());
-
-        if !i2c.stat().read().slvstate().is_slave_address() {
-            return Err(TransferError::AddressNack.into());
-        }
-
-        i2c.slvctl().modify(|_, w| w.slvcontinue().continue_());
-
-        Ok(())
-    }
 }
 
 impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Blocking, D> {
@@ -238,16 +226,54 @@ impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Blocking, D> {
 
 impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Async, D> {
     /// Listen for commands from the I2C Master asynchronously
-    pub async fn listen(&mut self, request: &mut [u8], expect_stop: bool) -> Result<()> {
+    pub async fn listen(&mut self) -> Result<Command> {
         let i2c = self.bus.i2c();
 
-        // Skip address phase if we are already in receive mode
-        if !i2c.stat().read().slvstate().is_slave_receive() {
-            self.block_until_addressed().await?;
+        // Disable DMA
+        i2c.slvctl().write(|w| w.slvdma().disabled());
+
+        // Check whether we already have a matched address and just waiting
+        // for software ack/nack
+        if !i2c.stat().read().slvpending().is_pending() {
+            self.poll_sw_action().await;
         }
 
-        // Verify that we are ready to receive after addressed
-        if !i2c.stat().read().slvstate().is_slave_receive() {
+        if i2c.stat().read().slvstate().is_slave_address() {
+            i2c.slvctl().write(|w| w.slvcontinue().continue_());
+        } else {
+            // If we are not addressed here, then we have issues.
+            return Err(TransferError::OtherBusError.into());
+        }
+
+        // Poll for HW to transitioning from addressed to receive/transmit
+        self.poll_sw_action().await;
+
+        // We are deselected, so it must be an 0 byte write transaction
+        if i2c.stat().read().slvdesel().is_deselected() {
+            // Clear the deselected bit
+            i2c.stat().write(|w| w.slvdesel().deselected());
+            return Ok(Command::Probe);
+        }
+
+        let state = i2c.stat().read().slvstate().variant();
+        match state {
+            Some(crate::pac::i2c0::stat::Slvstate::SlaveReceive) => Ok(Command::Write),
+            Some(crate::pac::i2c0::stat::Slvstate::SlaveTransmit) => Ok(Command::Read),
+            _ => Err(TransferError::OtherBusError.into()),
+        }
+    }
+
+    /// Respond to write command from master
+    pub async fn respond_to_write(&mut self, buf: &mut [u8]) -> Result<Response> {
+        let i2c = self.bus.i2c();
+
+        // Verify that we are ready for write
+        let stat = i2c.stat().read();
+        if !stat.slvstate().is_slave_receive() {
+            // 0 byte write
+            if stat.slvdesel().is_deselected() {
+                return Ok(Response::Complete(0));
+            }
             return Err(TransferError::ReadFail.into());
         }
 
@@ -256,31 +282,31 @@ impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Async, D> {
 
         // Enable interrupt
         i2c.intenset()
-            .write(|w| w.slvpendingen().set_bit().slvdeselen().set_bit());
+            .write(|w| w.slvpendingen().enabled().slvdeselen().enabled());
 
         let options = dma::transfer::TransferOptions::default();
         self.dma_ch
             .as_mut()
             .unwrap()
-            .read_from_peripheral(i2c.slvdat().as_ptr() as *mut u8, request, options);
+            .read_from_peripheral(i2c.slvdat().as_ptr() as *mut u8, buf, options);
 
         poll_fn(|cx| {
             let i2c = self.bus.i2c();
+            let dma = self.dma_ch.as_ref().unwrap();
             self.bus.waker().register(cx.waker());
-            self.dma_ch.as_ref().unwrap().get_waker().register(cx.waker());
+            dma.get_waker().register(cx.waker());
 
-            //check for readyness
-            if i2c.stat().read().slvpending().bit_is_set() {
+            let stat = i2c.stat().read();
+            // Did master send a stop?
+            if stat.slvdesel().is_deselected() {
                 return Poll::Ready(());
             }
-
-            if i2c.stat().read().slvdesel().bit_is_set() {
-                i2c.stat().write(|w| w.slvdesel().deselected());
+            // Does SW need to intervene?
+            if stat.slvpending().is_pending() {
                 return Poll::Ready(());
             }
-
-            // Only check DMA status if we are not expecting a stop
-            if !expect_stop && !self.dma_ch.as_ref().unwrap().is_active() {
+            // Did we complete the DMA transfer and does the master still have more data for us?
+            if !dma.is_active() && stat.slvstate().is_slave_receive() {
                 return Poll::Ready(());
             }
 
@@ -288,19 +314,33 @@ impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Async, D> {
         })
         .await;
 
-        // Disable interrupts
-        i2c.intenclr()
-            .write(|w| w.slvpendingclr().set_bit().slvdeselclr().set_bit());
+        // Complete DMA transaction and get transfer count
+        let xfer_count = self.abort_dma(buf.len());
+        let stat = i2c.stat().read();
+        // We got a stop from master, either way this transaction is
+        // completed
+        if stat.slvdesel().is_deselected() {
+            // Clear the deselected bit
+            i2c.stat().write(|w| w.slvdesel().deselected());
 
-        Ok(())
+            return Ok(Response::Complete(xfer_count));
+        } else if stat.slvstate().is_slave_address() {
+            // We are addressed again, so this must be a restart
+            return Ok(Response::Complete(xfer_count));
+        } else if stat.slvstate().is_slave_receive() {
+            // That was a partial transaction, the master want to send more
+            // data
+            return Ok(Response::Pending(xfer_count));
+        }
+
+        Err(TransferError::ReadFail.into())
     }
 
-    /// Respond to commands from the I2C Master asynchronously
-    pub async fn respond(&mut self, response: &[u8]) -> Result<()> {
+    /// Respond to read command from master
+    pub async fn respond_to_read(&mut self, buf: &[u8]) -> Result<Response> {
         let i2c = self.bus.i2c();
-        self.block_until_addressed().await?;
 
-        // Verify that we are ready for transmit after addressed
+        // Verify that we are ready for transmit
         if !i2c.stat().read().slvstate().is_slave_transmit() {
             return Err(TransferError::WriteFail.into());
         }
@@ -308,27 +348,33 @@ impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Async, D> {
         // Enable DMA
         i2c.slvctl().write(|w| w.slvdma().enabled());
 
-        // Enable interrupt
+        // Enable interrupts
         i2c.intenset()
-            .write(|w| w.slvpendingen().set_bit().slvdeselen().set_bit());
+            .write(|w| w.slvpendingen().enabled().slvdeselen().enabled());
 
         let options = dma::transfer::TransferOptions::default();
         self.dma_ch
             .as_mut()
             .unwrap()
-            .write_to_peripheral(response, i2c.slvdat().as_ptr() as *mut u8, options);
+            .write_to_peripheral(buf, i2c.slvdat().as_ptr() as *mut u8, options);
 
         poll_fn(|cx| {
             let i2c = self.bus.i2c();
+            let dma = self.dma_ch.as_ref().unwrap();
             self.bus.waker().register(cx.waker());
-            self.dma_ch.as_ref().unwrap().get_waker().register(cx.waker());
+            dma.get_waker().register(cx.waker());
 
-            if i2c.stat().read().slvpending().bit_is_set() {
+            let stat = i2c.stat().read();
+            // Master sent a nack or stop
+            if stat.slvdesel().is_deselected() {
                 return Poll::Ready(());
             }
-
-            if i2c.stat().read().slvdesel().bit_is_set() {
-                i2c.stat().write(|w| w.slvdesel().deselected());
+            // We need SW intervention
+            if stat.slvpending().is_pending() {
+                return Poll::Ready(());
+            }
+            // Did we complete the DMA transfer and master is still waiting for more data
+            if !dma.is_active() && stat.slvstate().is_slave_transmit() {
                 return Poll::Ready(());
             }
 
@@ -336,10 +382,57 @@ impl<FC: Instance, D: dma::Instance> I2cSlave<'_, FC, Async, D> {
         })
         .await;
 
-        // Disable interrupts
-        i2c.intenclr()
-            .write(|w| w.slvpendingclr().set_bit().slvdeselclr().set_bit());
+        // Complete DMA transaction and get transfer count
+        let xfer_count = self.abort_dma(buf.len());
+        let stat = i2c.stat().read();
+        // we got a nack or a stopfrom master, either way this transaction is
+        // completed
+        if stat.slvdesel().is_deselected() {
+            // clear the deselect bit
+            i2c.stat().write(|w| w.slvdesel().deselected());
 
-        Ok(())
+            return Ok(Response::Complete(xfer_count));
+        } else if stat.slvstate().is_slave_transmit() {
+            // That was a partial transaction, the master wants more data
+            return Ok(Response::Pending(buf.len()));
+        }
+
+        Err(TransferError::WriteFail.into())
+    }
+
+    async fn poll_sw_action(&self) {
+        let i2c = self.bus.i2c();
+
+        i2c.intenset()
+            .write(|w| w.slvpendingen().enabled().slvdeselen().enabled());
+
+        poll_fn(|cx: &mut core::task::Context<'_>| {
+            self.bus.waker().register(cx.waker());
+
+            let stat = i2c.stat().read();
+            if stat.slvdesel().is_deselected() {
+                return Poll::Ready(());
+            }
+            if stat.slvpending().is_pending() {
+                return Poll::Ready(());
+            }
+
+            Poll::Pending
+        })
+        .await;
+    }
+
+    /// Complete DMA and return bytes transfer
+    fn abort_dma(&self, xfer_size: usize) -> usize {
+        // abort DMA if DMA is not compelted
+        let dma = self.dma_ch.as_ref().unwrap();
+        let remain_xfer_count = dma.get_xfer_count();
+        let mut xfer_count = xfer_size;
+        if dma.is_active() && remain_xfer_count != 0x3FF {
+            xfer_count -= remain_xfer_count as usize + 1;
+            dma.abort();
+        }
+
+        xfer_count
     }
 }


### PR DESCRIPTION
Continuous w, r, w+r solid

Known failure condition:
- Having to call multiple respond_to_read() to complete an i2c transaction, we would get the DMA complete interrupt. However, slave status is in addressed (0x0) instead of transmit. so we don't get out of the polling loop. Then we are just stuck because the master is still expecting more data.