### PR TITLE
i2c: remove pull argument from slave examples

### DIFF
--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -9,7 +9,6 @@ use embassy_imxrt::i2c::{
     slave::{Address, I2cSlave},
     Async,
 };
-use embassy_imxrt::iopctl::Pull;
 use embassy_imxrt::pac;
 use embassy_imxrt::peripherals::{DMA0_CH4, FLEXCOMM2};
 
@@ -55,15 +54,7 @@ async fn main(spawner: Spawner) {
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5
     //       Test program here: https://github.com/jerrysxie/pi5-i2c-test
     info!("i2cs example - I2c::new");
-    let i2c = I2cSlave::new_async(
-        p.FLEXCOMM2,
-        p.PIO0_18,
-        p.PIO0_17,
-        Pull::Down,
-        SLAVE_ADDR.unwrap(),
-        p.DMA0_CH4,
-    )
-    .unwrap();
+    let i2c = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 
     spawner.must_spawn(slave_service(i2c));
 }

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -9,7 +9,6 @@ use embassy_imxrt::i2c::{
     slave::{Address, I2cSlave},
     Blocking,
 };
-use embassy_imxrt::iopctl::Pull;
 use embassy_imxrt::pac;
 use embassy_imxrt::peripherals::{DMA0_CH4, FLEXCOMM2};
 
@@ -53,15 +52,7 @@ async fn main(spawner: Spawner) {
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5
     //       Test program here: https://github.com/jerrysxie/pi5-i2c-test
     info!("i2cs example - I2c::new");
-    let i2c = I2cSlave::new_blocking(
-        p.FLEXCOMM2,
-        p.PIO0_18,
-        p.PIO0_17,
-        Pull::Down,
-        SLAVE_ADDR.unwrap(),
-        p.DMA0_CH4,
-    )
-    .unwrap();
+    let i2c = I2cSlave::new_blocking(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 
     spawner.must_spawn(slave_service(i2c));
 }


### PR DESCRIPTION
Fix this leftover from the recent I2C refactor PR.