### PR TITLE
gpio: call gpio::init from HAL init()

### DIFF
--- a/examples/rt685s-evk/src/bin/clocks-blinky.rs
+++ b/examples/rt685s-evk/src/bin/clocks-blinky.rs
@@ -15,7 +15,6 @@ async fn main(_spawner: Spawner) {
     let embassy_p = embassy_imxrt::init(Default::default());
 
     info!("Initializing GPIO");
-    unsafe { gpio::init() };
 
     let mut led = gpio::Output::new(
         embassy_p.PIO0_26,

--- a/examples/rt685s-evk/src/bin/gpio-async-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-async-input.rs
@@ -37,7 +37,6 @@ async fn main(spawner: Spawner) {
     let p = embassy_imxrt::init(Default::default());
 
     debug!("Initializing GPIO");
-    unsafe { gpio::init() };
 
     let mut output = gpio::Output::new(
         p.PIO1_2,

--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -13,7 +13,6 @@ async fn main(_spawner: Spawner) {
     let p = embassy_imxrt::init(Default::default());
 
     info!("Initializing GPIO");
-    unsafe { gpio::init() };
 
     let mut led = gpio::Output::new(
         p.PIO0_26,

--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -14,7 +14,6 @@ async fn main(_spawner: Spawner) {
     let p = embassy_imxrt::init(Default::default());
 
     info!("Initializing GPIO");
-    unsafe { gpio::init() };
 
     // Start with a level sensing disabled, output only state
     let flex = gpio::Flex::<SenseDisabled>::new(p.PIO1_0);

--- a/examples/rt685s-evk/src/bin/gpio-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-input.rs
@@ -13,7 +13,6 @@ async fn main(_spawner: Spawner) {
     let p = embassy_imxrt::init(Default::default());
 
     info!("Initializing GPIO");
-    unsafe { gpio::init() };
 
     let monitor = gpio::Input::new(p.PIO1_0, gpio::Pull::None, gpio::Inverter::Disabled);
 

--- a/examples/rt685s-evk/src/bin/time-driver-blinky.rs
+++ b/examples/rt685s-evk/src/bin/time-driver-blinky.rs
@@ -14,7 +14,6 @@ async fn main(_spawner: Spawner) -> ! {
     let embassy_p = embassy_imxrt::init(Default::default());
 
     info!("Initializing GPIO");
-    unsafe { gpio::init() };
 
     let mut led = gpio::Output::new(
         embassy_p.PIO0_26,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -107,11 +107,7 @@ fn irq_handler(port_wakers: &[Option<&PortWaker>]) {
 
 /// Initialization Logic
 /// Note: GPIO port clocks are initialized in the clocks module.
-/// # Safety
-///
-/// This function enables GPIO INT A interrupt. It should not be called
-/// until you are ready to handle the interrupt
-pub unsafe fn init() {
+pub(crate) fn init() {
     // Enable GPIO clocks
     enable_and_reset::<peripherals::HSGPIO0>();
     enable_and_reset::<peripherals::HSGPIO1>();
@@ -124,7 +120,13 @@ pub unsafe fn init() {
 
     // Enable INTA
     interrupt::GPIO_INTA.unpend();
-    interrupt::GPIO_INTA.enable();
+
+    // SAFETY:
+    //
+    // At this point, all GPIO interrupts are masked. No interrupts
+    // will trigger until a pin is configured as Input, which can only
+    // happen after initialization of the HAL
+    unsafe { interrupt::GPIO_INTA.enable() };
 }
 
 mod sealed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,6 +478,7 @@ pub fn init(config: config::Config) -> Peripherals {
         #[cfg(feature = "time-driver")]
         time_driver::init(config.time_interrupt_priority);
         dma::init();
+        gpio::init();
     }
 
     peripherals


### PR DESCRIPTION
Instead of exposing gpio::init(), call it from the HAL's init function. With this change we can also assume that all GPIO interrupts are masked at that point (reset state of the GPIO blocks) and remove the use of unsafe as there's no way for users to call gpio::init() from an invalid state.