### PR TITLE
Fix timer wake

### DIFF
--- a/src/time_driver.rs
+++ b/src/time_driver.rs
@@ -94,6 +94,9 @@ impl TimerDriver {
         // as a compare register for triggering an alarm so to avoid unnecessary triggers
         // after initialization, this is set to 0x:FFFF_FFFF
         self.compare_reg().write(|w| unsafe { w.gpdata().bits(u32::MAX) });
+        // safety: writing a value to the 1kHz RTC wake counter is always considered unsafe.
+        // The following loads 10 into the count-down timer.
+        r.wake().write(|w| unsafe { w.bits(0xA) });
         interrupt::RTC.set_priority(irq_prio);
         unsafe { interrupt::RTC.enable() };
     }


### PR DESCRIPTION
On some platforms the timer does not work as the rtc wake is not programmed correctly.
Fix the issue by setting the rtc wake everytime we get an interrupt. 