### PR TITLE
Add clippy.toml file

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 9


### PR DESCRIPTION
Silence too-many-arguments warning caused by UART CTS/RTS. We need all those pins in order to have functional flow control.