### PR TITLE
Upstream embassy updates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -209,7 +209,7 @@ jobs:
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
         workdir: [ ".", "examples/rt685s-evk"]
-        msrv: ["1.79"] # We're relying on namespaced-features, which
+        msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -220,6 +220,8 @@ jobs:
                        #
                        # embassy-time requires 1.79 due to
                        # collapse_debuginfo
+                       #
+                       # embassy upstream switched to rust 1.83
     name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,12 @@ defmt = ["dep:defmt", "mimxrt685s-pac/defmt"]
 ## Enable features requiring `embassy-time`
 time = ["dep:embassy-time"]
 ## Enable custom embassy time-driver implementation, using 1kHz RTC
-time-driver = ["dep:embassy-time-driver", "embassy-time-driver?/tick-hz-1_000"]
+time-driver = ["dep:embassy-time-driver", "embassy-time-driver?/tick-hz-1_000", "dep:embassy-time-queue-driver"]
 
 [dependencies]
 embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", optional = true }
+embassy-time-queue-driver = { git = "https://github.com/embassy-rs/embassy", optional = true }
 embassy-time = { git = "https://github.com/embassy-rs/embassy", optional = true }
 embassy-futures = { git = "https://github.com/embassy-rs/embassy" }
 embassy-hal-internal = { git = "https://github.com/embassy-rs/embassy", features = [

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -27,7 +27,6 @@ embassy-executor = { git = "https://github.com/embassy-rs/embassy", features = [
     "executor-thread",
     "executor-interrupt",
     "defmt",
-    "integrated-timers",
 ] }
 embassy-futures = { git = "https://github.com/embassy-rs/embassy" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy", features = [


### PR DESCRIPTION
Updates needed to compile embassy-imxrt against latest embassy upstream. Make sure to remove your local Cargo.toml file.