### PR TITLE
Add a nightly workflow

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -1,0 +1,63 @@
+# This workflow runs every morning at midnight. It will run cargo hack
+# and a build with msrv. If any dependency breaks our crate, we will
+# know ASAP.
+#
+# - check: build with all features
+# - msrv: check that the msrv specified in the crate is correct
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+name: rolling
+jobs:
+
+  check:
+    runs-on: ubuntu-latest
+    name: ubuntu / stable / features
+    needs: commit_list
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: cargo check
+        run: cargo check --all-features
+
+  msrv:
+    runs-on: ubuntu-latest
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        msrv: ["1.83"] # We're relying on namespaced-features, which
+                       # was released in 1.60
+                       #
+                       # We also depend on `fixed' which requires rust
+                       # 1.71
+                       #
+                       # Additionally, we depend on embedded-hal-async
+                       # which requires 1.75
+                       #
+                       # embassy-time requires 1.79 due to
+                       # collapse_debuginfo
+                       #
+                       # embassy upstream switched to rust 1.83
+    name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install ${{ matrix.msrv }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.msrv }}
+      - name: cargo +${{ matrix.msrv }} check
+        run: cargo check

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![no-std](https://github.com/pop-project/embassy-imxrt/actions/workflows/nostd.yml/badge.svg)](https://github.com/pop-project/embassy-imxrt/actions/workflows/nostd.yml)
 [![check](https://github.com/pop-project/embassy-imxrt/actions/workflows/check.yml/badge.svg)](https://github.com/pop-project/embassy-imxrt/actions/workflows/check.yml)
+[![rolling](https://github.com/pop-project/embassy-imxrt/actions/workflows/rolling.yml/badge.svg)](https://github.com/pop-project/embassy-imxrt/actions/workflows/rolling.yml)
 [![LICENSE](https://img.shields.io/badge/License-MIT-blue)](./LICENSE)
 
 ## Introduction


### PR DESCRIPTION
This workflow should help us catch regressions caused by upstream updates.

Fixes #213 