### PR TITLE
rolling: remove commit_list dependency

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -17,7 +17,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     name: ubuntu / stable / features
-    needs: commit_list
     strategy:
       fail-fast: false
     steps:
@@ -33,7 +32,6 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    needs: commit_list
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We only need to verify HEAD in a nightly build. Remove the left-over commit_list dependency.