### PR TITLE
Fixed barrier instruction sequence

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -27,7 +27,7 @@ pub(crate) unsafe fn init() {
         });
 
         // Clear instruction and data pipeline
-        cortex_m::asm::isb();
         cortex_m::asm::dsb();
+        cortex_m::asm::isb();
     })
 }


### PR DESCRIPTION
When there is any system context changing operation, we would want next set of instructions including memory access instructions to execute with the new settings created by the context changing operation.

We use DSB to synchronize the instruction pipeline where every instruction after DSB will execute after all the instruction before the DSB. This is done to make sure, when we flush the pipeline with ISB, it happens once the context changing operation is completed.

Then comes ISB to cleanup the CPU pipelines. After that, CPU fetches the instructions again from the memory. Since Cortex M series do not have instruction cache, the instructions are fetched from the memory directly.