### PR TITLE
[BREAKING] Update rt633.yaml

### DIFF
--- a/examples/rt633/rt633.yaml
+++ b/examples/rt633/rt633.yaml
@@ -10,7 +10,7 @@ variants:
   - name: cm33
     type: armv8m
     core_access_options: !Arm
-      ap: 0
+      ap: !v1 0
   memory_map:
   - !Ram
     name: SRAM_ROM


### PR DESCRIPTION
probe-rs 0.27.0 changed the format of chip description files. Now we must tell the version of the access port.