### PR TITLE
crc: use more standard names for configuration parameters

### DIFF
--- a/examples/rt685s-evk/src/bin/crc.rs
+++ b/examples/rt685s-evk/src/bin/crc.rs
@@ -5,18 +5,170 @@ extern crate embassy_imxrt_examples;
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_imxrt::crc::{Config, Crc};
+use embassy_imxrt::crc::{Config, Crc, Polynomial};
 use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
-    let p = embassy_imxrt::init(Default::default());
+    let mut p = embassy_imxrt::init(Default::default());
+    let data = b"123456789";
 
     info!("Initializing CRC");
 
-    let mut crc = Crc::new(p.CRC, Default::default());
-    let output = crc.feed_bytes(b"123456789");
+    // CRC-CCITT
+    let mut crc = Crc::new(&mut p.CRC, Default::default());
+    let output = crc.feed_bytes(data);
     defmt::assert_eq!(output, 0x29b1);
 
-    cortex_m::asm::bkpt();
+    // CRC16-ARC
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc16,
+            reverse_in: true,
+            reverse_out: true,
+            complement_out: false,
+            seed: 0,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0xbb3d);
+
+    // CRC16-CMS
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc16,
+            reverse_in: false,
+            reverse_out: false,
+            complement_out: false,
+            seed: 0xffff,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0xaee7);
+
+    // CRC16-DDS-110
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc16,
+            reverse_in: false,
+            reverse_out: false,
+            complement_out: false,
+            seed: 0x800d,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0x9ecf);
+
+    // CRC16-MAXIM-DOW
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc16,
+            reverse_in: true,
+            reverse_out: true,
+            complement_out: true,
+            seed: 0,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0x44c2);
+
+    // CRC16-MODBUS
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc16,
+            reverse_in: true,
+            reverse_out: true,
+            complement_out: false,
+            seed: 0xffff,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0x4b37);
+
+    // CRC32-BZIP2
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc32,
+            reverse_in: false,
+            reverse_out: false,
+            complement_out: true,
+            seed: 0xffff_ffff,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0xfc89_1918);
+
+    // CRC32-CKSUM
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc32,
+            reverse_in: false,
+            reverse_out: false,
+            complement_out: true,
+            seed: 0,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0x765e_7680);
+
+    // CRC32-ISO-HDLC
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc32,
+            reverse_in: true,
+            reverse_out: true,
+            complement_out: true,
+            seed: 0xffff_ffff,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0xcbf4_3926);
+
+    // CRC32-JAMCRC
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc32,
+            reverse_in: true,
+            reverse_out: true,
+            complement_out: false,
+            seed: 0xffff_ffff,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0x340b_c6d9);
+
+    // CRC32-MPEG-2
+    let mut crc = Crc::new(
+        &mut p.CRC,
+        Config {
+            polynomial: Polynomial::Crc32,
+            reverse_in: false,
+            reverse_out: false,
+            complement_out: false,
+            seed: 0xffff_ffff,
+            ..Default::default()
+        },
+    );
+    let output = crc.feed_bytes(data);
+    defmt::assert_eq!(output, 0x0376_e6e7);
+
+    loop {}
 }

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -20,16 +20,16 @@ pub struct Config {
     pub polynomial: Polynomial,
 
     /// Reverse bit order of input?
-    pub bit_order_input_reverse: bool,
+    pub reverse_in: bool,
 
     /// 1's complement input?
-    pub input_complement: bool,
+    pub complement_in: bool,
 
     /// Reverse CRC bit order?
-    pub bit_order_crc_reverse: bool,
+    pub reverse_out: bool,
 
     /// 1's complement CRC?
-    pub crc_complement: bool,
+    pub complement_out: bool,
 
     /// CRC Seed
     pub seed: u32,
@@ -40,18 +40,18 @@ impl Config {
     #[must_use]
     pub fn new(
         polynomial: Polynomial,
-        bit_order_input_reverse: bool,
-        input_complement: bool,
-        bit_order_crc_reverse: bool,
-        crc_complement: bool,
+        reverse_in: bool,
+        complement_in: bool,
+        reverse_out: bool,
+        complement_out: bool,
         seed: u32,
     ) -> Self {
         Config {
             polynomial,
-            bit_order_input_reverse,
-            input_complement,
-            bit_order_crc_reverse,
-            crc_complement,
+            reverse_in,
+            complement_in,
+            reverse_out,
+            complement_out,
             seed,
         }
     }
@@ -61,10 +61,10 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             polynomial: Polynomial::default(),
-            bit_order_input_reverse: false,
-            input_complement: false,
-            bit_order_crc_reverse: false,
-            crc_complement: false,
+            reverse_in: false,
+            complement_in: false,
+            reverse_out: false,
+            complement_out: false,
             seed: 0xffff,
         }
     }
@@ -115,13 +115,13 @@ impl<'d> Crc<'d> {
         self.info.regs.mode().write(|w| {
             unsafe { w.crc_poly().bits(self._config.polynomial.into()) }
                 .bit_rvs_wr()
-                .variant(self._config.bit_order_input_reverse)
+                .variant(self._config.reverse_in)
                 .cmpl_wr()
-                .variant(self._config.input_complement)
+                .variant(self._config.complement_in)
                 .bit_rvs_sum()
-                .variant(self._config.bit_order_crc_reverse)
+                .variant(self._config.reverse_out)
                 .cmpl_sum()
-                .variant(self._config.crc_complement)
+                .variant(self._config.complement_out)
         });
 
         // Init CRC value


### PR DESCRIPTION
Reverse In, Complement In, Reverse Out, and Complement Out are more standard names used elsewhere. Let's match the naming convention to make it easier for those using this driver.

While at that, also add tests for all three CRC types supported.