### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -16,7 +16,7 @@ pub mod master;
 /// I2C Slave Driver
 pub mod slave;
 
-/// shorthand for -> Result<T>
+/// shorthand for -> `Result<T>`
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Bus speed (nominal SCL, no clock stretching)

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -130,7 +130,7 @@ pub enum Error {
     /// TX Busy
     TxBusy,
 }
-/// shorthand for -> Result<T>
+/// shorthand for -> `Result<T>`
 pub type Result<T> = core::result::Result<T, Error>;
 
 impl<'a, M: Mode> UartTx<'a, M> {


### PR DESCRIPTION
Fix the following warnigs:

```
warning: unclosed HTML tag `T`
  --> src\i2c\mod.rs:19:28
   |
19 | /// shorthand for -> Result<T>
   |                            ^^^
   |
   = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
help: try marking as source code
   |
19 | /// shorthand for -> `Result<T>`
   |                      +         +

warning: unclosed HTML tag `T`
   --> src\uart.rs:133:28
    |
133 | /// shorthand for -> Result<T>
    |                            ^^^
    |
help: try marking as source code
    |
133 | /// shorthand for -> `Result<T>`
    |                      +         +
```