### PR TITLE
rolling: allow rolling to work again

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -28,7 +28,9 @@ jobs:
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: cargo check
-        run: cargo check --all-features
+        run: |
+          cargo check -F mimxrt633s,rt,defmt,time,time-driver,unstable-pac
+          cargo check -F mimxrt685s,rt,defmt,time,time-driver,unstable-pac
 
   msrv:
     runs-on: ubuntu-latest
@@ -58,4 +60,6 @@ jobs:
         with:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
-        run: cargo check
+        run: |
+          cargo check -F mimxrt633s,rt,defmt,time,time-driver,unstable-pac
+          cargo check -F mimxrt685s,rt,defmt,time,time-driver,unstable-pac


### PR DESCRIPTION
We must pass the correct flags for the rolling workflow as well, otherwise a `chip` module won't exist. D'oh.