### PR TITLE
Update CaptureTimer to calculate fan speed

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -436,9 +436,8 @@ impl<M: Mode> CaptureTimer<M> {
     /// Captured clock = (Capture value - previous counter value)
     fn get_event_capture_time_us(&self) -> u32 {
         let time_float = (self.event_clock_counts as f32 / self.clk_freq as f32) * 1000000.0;
-        let time_int = time_float as u32 as f32;
-        let interger_part = time_int as u32;
-        interger_part
+        let integer_part = time_float as u32;
+        integer_part
     }
 
     fn reset_and_enable(&self) {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -436,11 +436,10 @@ impl<M: Mode> CaptureTimer<M> {
     /// Captured clock = (Capture value - previous counter value)
     fn get_event_capture_time_us(&self) -> u32 {
         let time_float = (self.event_clock_counts as f32 / self.clk_freq as f32) * 1000000.0;
-        time_float as u32
-        // let time_int = time_float as u32 as f32;
-        // let interger_part = time_int as u32;
-        // let decimal_part = ((time_float - time_int) * 1000000.0) as u32;
-        // interger_part + decimal_part
+        let time_int = time_float as u32 as f32;
+        let interger_part = time_int as u32;
+        let decimal_part = ((time_float - time_int) * 1000000.0) as u32;
+        interger_part + decimal_part
     }
 
     fn reset_and_enable(&self) {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -438,8 +438,7 @@ impl<M: Mode> CaptureTimer<M> {
         let time_float = (self.event_clock_counts as f32 / self.clk_freq as f32) * 1000000.0;
         let time_int = time_float as u32 as f32;
         let interger_part = time_int as u32;
-        let decimal_part = ((time_float - time_int) * 1000000.0) as u32;
-        interger_part + decimal_part
+        interger_part
     }
 
     fn reset_and_enable(&self) {


### PR DESCRIPTION
**Why?**
To calculate fan speed, we need to capture fan TACH signal period time, from this rising edge to next rising edge.

**What changes?**
1. Implement new function "capture_cycle_time_us" for CaptureTimer. This function trigger capture twice and return time us between these two captures.
2. Fix return value in "get_event_capture_time_us".

**How to test?**
Result from print log match with LA waveform

From print log
11:04:48.115 : (86918650) fan tach cycle 4355 us
11:04:48.147 : (86918650) calculated fan rpm = 6888

LA waveform of fan tach pin
![image](https://github.com/user-attachments/assets/4dbcb2a3-5fb6-47bd-96b5-2b440fe18add)
