### PR TITLE
Update CaptureTimer to calculate fan speed

### DIFF
--- a/examples/rt685s-evk/src/bin/timer.rs
+++ b/examples/rt685s-evk/src/bin/timer.rs
@@ -47,15 +47,19 @@ async fn main(_spawner: Spawner) {
     // Creating a separate block to test Timer Drop logic
     {
         let sfro = ClockConfig::crystal().sfro;
-        let mut cap_async_tmr = CaptureTimer::new_async(p.CTIMER0_CAPTURE_CHANNEL0, sfro);
+        let mut cap_async_tmr = CaptureTimer::new_async(p.CTIMER0_CAPTURE_CHANNEL0, p.PIO1_7, sfro);
 
         // pass the input mux number, Input pin and Input pin edge user is interested in
         // Input mux details can be found in NXP user manual section 8.6.8 and Pin Function Table in section 7.5.3
-        let event_time_ms = cap_async_tmr
-            .capture_event_time_us(TriggerInput::TrigIn9, p.PIO1_7, CaptureChEdge::Falling)
-            .await;
+        let event_time_us = cap_async_tmr.capture_event_time_us(CaptureChEdge::Falling).await;
 
-        info!("Capture timer expired in = {} ms", event_time_ms);
+        info!("Capture timer expired in = {} us", event_time_us);
+
+        let sfro = ClockConfig::crystal().sfro;
+        let mut cap_async_tmr = CaptureTimer::new_async(p.CTIMER4_CAPTURE_CHANNEL0, p.PIO0_5, sfro);
+        let event_time_us = cap_async_tmr.capture_cycle_time_us(CaptureChEdge::Rising).await;
+
+        info!("Capture timer expired, time between two capture = {} us", event_time_us);
     }
 
     loop {


### PR DESCRIPTION
**Why?**
To calculate fan speed, we need to capture fan TACH signal period time, from this rising edge to next rising edge.

**What changes?**
1. Implement new function "capture_cycle_time_us" for CaptureTimer. This function trigger capture twice and return time us between these two captures.
2. Fix return value in "get_event_capture_time_us".

**How to test?**
Result from print log match with LA waveform

From print log
11:04:48.115 : (86918650) fan tach cycle 4355 us
11:04:48.147 : (86918650) calculated fan rpm = 6888

LA waveform of fan tach pin
![image](https://github.com/user-attachments/assets/4dbcb2a3-5fb6-47bd-96b5-2b440fe18add)

#170
