### PR TITLE
Add NoDma I2C master async bus implementation

### DIFF
--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -13,7 +13,7 @@ const TEST_LEN: usize = 16;
 
 macro_rules! test_dma_channel {
     ($peripherals:expr, $instance:ident, $number:expr) => {
-        let ch = Dma::reserve_channel::<$instance>($peripherals.$instance);
+        let ch = Dma::reserve_channel::<$instance>($peripherals.$instance).unwrap();
         dma_test(ch, $number).await;
     };
 }

--- a/src/hashcrypt/mod.rs
+++ b/src/hashcrypt/mod.rs
@@ -104,7 +104,7 @@ impl<'d> Hashcrypt<'d, Async> {
         peripheral: impl Peripheral<P = HASHCRYPT> + 'd,
         dma_ch: impl Peripheral<P = impl HashcryptDma> + 'd,
     ) -> Self {
-        Self::new_inner(peripheral, Some(dma::Dma::reserve_channel(dma_ch)))
+        Self::new_inner(peripheral, dma::Dma::reserve_channel(dma_ch))
     }
 
     /// Start a new SHA256 hash

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -346,3 +346,21 @@ impl_dma!(FLEXCOMM6, Master, DMA0_CH13);
 
 impl_dma!(FLEXCOMM7, Slave, DMA0_CH14);
 impl_dma!(FLEXCOMM7, Master, DMA0_CH15);
+
+macro_rules! impl_nodma {
+    ($fcn:ident, $mode:ident) => {
+        paste! {
+            impl [<$mode Dma>]<crate::peripherals::$fcn> for crate::dma::NoDma {}
+        }
+    };
+}
+
+impl_nodma!(FLEXCOMM0, Master);
+impl_nodma!(FLEXCOMM1, Master);
+impl_nodma!(FLEXCOMM2, Master);
+impl_nodma!(FLEXCOMM3, Master);
+impl_nodma!(FLEXCOMM4, Master);
+impl_nodma!(FLEXCOMM5, Master);
+impl_nodma!(FLEXCOMM6, Master);
+impl_nodma!(FLEXCOMM7, Master);
+impl_nodma!(FLEXCOMM15, Master);

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -258,12 +258,17 @@ impl<'a> I2cSlave<'a, Async> {
         T::into_i2c();
 
         let ch = dma::Dma::reserve_channel(dma_ch);
-        let this = Self::new_inner::<T>(_bus, scl, sda, address, Some(ch))?;
 
-        T::Interrupt::unpend();
-        unsafe { T::Interrupt::enable() };
+        if ch.is_some() {
+            let this = Self::new_inner::<T>(_bus, scl, sda, address, Some(ch.unwrap()))?;
 
-        Ok(this)
+            T::Interrupt::unpend();
+            unsafe { T::Interrupt::enable() };
+
+            Ok(this)
+        } else {
+            Err(super::Error::UnsupportedConfiguration)
+        }
     }
 }
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -556,7 +556,7 @@ impl<'a> UartTx<'a, Async> {
 
         let tx_dma = dma::Dma::reserve_channel(tx_dma);
 
-        Ok(Self::new_inner::<T>(Some(tx_dma)))
+        Ok(Self::new_inner::<T>(tx_dma))
     }
 
     /// Transmit the provided buffer asynchronously.
@@ -687,7 +687,7 @@ impl<'a> UartRx<'a, Async> {
 
         let rx_dma = dma::Dma::reserve_channel(rx_dma);
 
-        Ok(Self::new_inner::<T>(Some(rx_dma)))
+        Ok(Self::new_inner::<T>(rx_dma))
     }
 
     /// Read from UART RX asynchronously.
@@ -788,8 +788,8 @@ impl<'a> Uart<'a, Async> {
 
         Ok(Self {
             info: T::info(),
-            tx: UartTx::new_inner::<T>(Some(tx_dma)),
-            rx: UartRx::new_inner::<T>(Some(rx_dma)),
+            tx: UartTx::new_inner::<T>(tx_dma),
+            rx: UartRx::new_inner::<T>(rx_dma),
         })
     }
 
@@ -834,8 +834,8 @@ impl<'a> Uart<'a, Async> {
 
         Ok(Self {
             info: T::info(),
-            tx: UartTx::new_inner::<T>(Some(tx_dma)),
-            rx: UartRx::new_inner::<T>(Some(rx_dma)),
+            tx: UartTx::new_inner::<T>(tx_dma),
+            rx: UartRx::new_inner::<T>(rx_dma),
         })
     }
 


### PR DESCRIPTION
Closes #327 

Some kicking off questions:
- The reason I need to make a `new_async_nodma()` fn instead of hijacking `new_async()` is because `new_async()` requires a dma_ch object that impls Peripheral and impls an interrupt with `MasterDma`. I tried creating structs to impl all that but I hit a wall.
- I added documentation saying NOT to use this and to prefer `new_async()`, except in the cases of the Flexcomm not having DMA support. Is this enough or do you think this should be gated behind some sort of feature flag to reduce the possibility of misuse?

EDIT: 
I was able to create a NoDma structure. I had to minimally modify the DMA api, specifically `reserve_channel()` now returns an option that will return None if NoDma is used.