### PR TITLE
Ensure GPIO pins are reset when used by a I2C {master, slave}, UART and ADC

### DIFF
--- a/examples/rt685s-evk/src/bin/clocks-blinky.rs
+++ b/examples/rt685s-evk/src/bin/clocks-blinky.rs
@@ -5,7 +5,7 @@ extern crate embassy_imxrt_examples;
 
 use defmt::{error, info};
 use embassy_executor::Spawner;
-use embassy_imxrt::iopctl::IopctlPin;
+use embassy_imxrt::iopctl::{IopctlFunctionPin, IopctlPin};
 use embassy_imxrt::{clocks, gpio};
 use embassy_time::Timer;
 use {defmt_rtt as _, embassy_imxrt as _, panic_probe as _};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -8,7 +8,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use paste::paste;
 
 use crate::clocks::{enable_and_reset, ClockConfig, ConfigurableClock};
-use crate::iopctl::{DriveMode, DriveStrength, Inverter, IopctlPin as Pin, Pull, SlewRate};
+use crate::iopctl::{DriveMode, DriveStrength, Inverter, IopctlFunctionPin, IopctlPin as Pin, Pull, SlewRate};
 use crate::pac::clkctl1::ct32bitfclksel::Sel;
 use crate::pac::Clkctl1;
 use crate::pwm::{CentiPercent, Hertz, MicroSeconds};


### PR DESCRIPTION
As the first step towards implementing `Drop` for all drivers, have the drivers own an instance of a `Pin` driver which takes care of resetting each pin when the parent peripheral driver is dropped.

A subsequent PR will tackle Flexcomm disable/reset for each peripheral.

I took care to change as little as possible. Ideally low level `Sealed` implementations are separated from high level embassy driver implementations. Currently this distinction is a bit blurry, and consequently a driver can be a bit messy. Good examples of these are the `SdaPin` and `CtsPin` traits and friends. The separation between `gpio` and `iopctl` could also be better. `IopctlPin` traits should be private.

Have not yet tested this PR on the EVK, as we are waiting for those to be delivered. I will update this PR once it has been tested.