### PR TITLE
Fixed recent regressions caused by upstream changes

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -2,11 +2,9 @@
 
 use core::marker::PhantomData;
 
-use embassy_hal_internal::into_ref;
-
 use crate::clocks::{enable_and_reset, SysconPeripheral};
 pub use crate::pac::crc_engine::mode::CrcPolynomial as Polynomial;
-use crate::{peripherals, Peripheral};
+use crate::{peripherals, Peri, PeripheralType};
 
 /// CRC driver.
 pub struct Crc<'d> {
@@ -73,11 +71,9 @@ impl Default for Config {
 
 impl<'d> Crc<'d> {
     /// Instantiates new CRC peripheral and initializes to default values.
-    pub fn new<T: Instance>(_peripheral: impl Peripheral<P = T> + 'd, config: Config) -> Self {
+    pub fn new<T: Instance>(_peripheral: Peri<'d, T>, config: Config) -> Self {
         // enable CRC clock
         enable_and_reset::<T>();
-
-        into_ref!(_peripheral);
 
         let mut instance = Self {
             info: T::info(),
@@ -180,7 +176,7 @@ trait SealedInstance {
 
 /// CRC instance trait.
 #[allow(private_bounds)]
-pub trait Instance: SealedInstance + Peripheral<P = Self> + SysconPeripheral + 'static + Send {}
+pub trait Instance: SealedInstance + PeripheralType + SysconPeripheral + 'static + Send {}
 
 impl Instance for peripherals::CRC {}
 

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -13,7 +13,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 use crate::clocks::enable_and_reset;
 use crate::dma::channel::Channel;
 use crate::peripherals::{self, DMA0};
-use crate::{interrupt, Peripheral};
+use crate::{interrupt, Peri, PeripheralType};
 
 // TODO:
 //
@@ -146,7 +146,7 @@ struct DmaInfo {
 
 impl<'d> Dma<'d> {
     /// Reserves a DMA channel for exclusive use
-    pub fn reserve_channel<T: Instance>(_inner: impl Peripheral<P = T> + 'd) -> Option<Channel<'d>> {
+    pub fn reserve_channel<T: Instance>(_inner: Peri<'d, T>) -> Option<Channel<'d>> {
         if T::info().is_some() {
             Some(Channel {
                 info: T::info().unwrap(),
@@ -164,7 +164,7 @@ trait SealedInstance {
 
 /// DMA instance trait
 #[allow(private_bounds)]
-pub trait Instance: SealedInstance + Peripheral<P = Self> + 'static + Send {
+pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this DMA instance
     type Interrupt: interrupt::typelevel::Interrupt;
 }

--- a/src/flexcomm.rs
+++ b/src/flexcomm.rs
@@ -1,13 +1,12 @@
 //! implements flexcomm interface wrapper for easier usage across modules
 
-use embassy_hal_internal::Peripheral;
 use paste::paste;
 
 use crate::clocks::{enable_and_reset, SysconPeripheral};
-use crate::pac;
 use crate::peripherals::{
     FLEXCOMM0, FLEXCOMM1, FLEXCOMM14, FLEXCOMM15, FLEXCOMM2, FLEXCOMM3, FLEXCOMM4, FLEXCOMM5, FLEXCOMM6, FLEXCOMM7,
 };
+use crate::{pac, PeripheralType};
 
 /// clock selection option
 #[derive(Copy, Clone, Debug)]
@@ -47,9 +46,7 @@ mod sealed {
 }
 
 /// primary low-level flexcomm interface
-pub(crate) trait FlexcommLowLevel:
-    sealed::Sealed + Peripheral<P = Self> + SysconPeripheral + 'static + Send
-{
+pub(crate) trait FlexcommLowLevel: sealed::Sealed + PeripheralType + SysconPeripheral + 'static + Send {
     // fetch the flexcomm register block for direct manipulation
     fn reg() -> &'static pac::flexcomm0::RegisterBlock;
 

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -2,13 +2,12 @@
 
 use core::marker::PhantomData;
 
-use embassy_hal_internal::Peripheral;
 use embassy_sync::waitqueue::AtomicWaker;
 use paste::paste;
 use sealed::Sealed;
 
 use crate::iopctl::IopctlPin as Pin;
-use crate::{dma, interrupt};
+use crate::{dma, interrupt, PeripheralType};
 
 /// I2C Master Driver
 pub mod master;
@@ -90,7 +89,7 @@ trait SealedInstance {
 
 /// shared functions between master and slave operation
 #[allow(private_bounds)]
-pub trait Instance: crate::flexcomm::IntoI2c + SealedInstance + Peripheral<P = Self> + 'static + Send {
+pub trait Instance: crate::flexcomm::IntoI2c + SealedInstance + PeripheralType + 'static + Send {
     /// Interrupt for this I2C instance.
     type Interrupt: interrupt::typelevel::Interrupt;
 }
@@ -174,13 +173,13 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 /// io configuration trait for easier configuration
-pub trait SclPin<Instance>: Pin + sealed::Sealed + Peripheral {
+pub trait SclPin<Instance>: Pin + sealed::Sealed + PeripheralType {
     /// convert the pin to appropriate function for SCL usage
     fn as_scl(&self);
 }
 
 /// io configuration trait for easier configuration
-pub trait SdaPin<Instance>: Pin + sealed::Sealed + Peripheral {
+pub trait SdaPin<Instance>: Pin + sealed::Sealed + PeripheralType {
     /// convert the pin to appropriate function for SDA usage
     fn as_sda(&self);
 }

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -4,7 +4,7 @@ use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::task::Poll;
 
-use embassy_hal_internal::{into_ref, Peripheral};
+use embassy_hal_internal::Peri;
 
 use super::{
     Async, Blocking, Info, Instance, InterruptHandler, Mode, Result, SclPin, SdaPin, SlaveDma, TransferError,
@@ -137,17 +137,13 @@ pub struct I2cSlave<'a, M: Mode> {
 impl<'a, M: Mode> I2cSlave<'a, M> {
     /// use flexcomm fc with Pins scl, sda as an I2C Master bus, configuring to speed and pull
     fn new_inner<T: Instance>(
-        _bus: impl Peripheral<P = T> + 'a,
-        scl: impl Peripheral<P = impl SclPin<T>> + 'a,
-        sda: impl Peripheral<P = impl SdaPin<T>> + 'a,
+        _bus: Peri<'a, T>,
+        scl: Peri<'a, impl SclPin<T>>,
+        sda: Peri<'a, impl SdaPin<T>>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
         address: Address,
         dma_ch: Option<dma::channel::Channel<'a>>,
     ) -> Result<Self> {
-        into_ref!(_bus);
-        into_ref!(scl);
-        into_ref!(sda);
-
         sda.as_sda();
         scl.as_scl();
 
@@ -206,9 +202,9 @@ impl<'a, M: Mode> I2cSlave<'a, M> {
 impl<'a> I2cSlave<'a, Blocking> {
     /// use flexcomm fc with Pins scl, sda as an I2C Master bus, configuring to speed and pull
     pub fn new_blocking<T: Instance>(
-        _bus: impl Peripheral<P = T> + 'a,
-        scl: impl Peripheral<P = impl SclPin<T>> + 'a,
-        sda: impl Peripheral<P = impl SdaPin<T>> + 'a,
+        _bus: Peri<'a, T>,
+        scl: Peri<'a, impl SclPin<T>>,
+        sda: Peri<'a, impl SdaPin<T>>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
         address: Address,
     ) -> Result<Self> {
@@ -244,13 +240,13 @@ impl<'a> I2cSlave<'a, Blocking> {
 impl<'a> I2cSlave<'a, Async> {
     /// use flexcomm fc with Pins scl, sda as an I2C Master bus, configuring to speed and pull
     pub fn new_async<T: Instance>(
-        _bus: impl Peripheral<P = T> + 'a,
-        scl: impl Peripheral<P = impl SclPin<T>> + 'a,
-        sda: impl Peripheral<P = impl SdaPin<T>> + 'a,
+        _bus: Peri<'a, T>,
+        scl: Peri<'a, impl SclPin<T>>,
+        sda: Peri<'a, impl SdaPin<T>>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'a,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
         address: Address,
-        dma_ch: impl Peripheral<P = impl SlaveDma<T>> + 'a,
+        dma_ch: Peri<'a, impl SlaveDma<T>>,
     ) -> Result<Self> {
         // TODO - clock integration
         let clock = crate::flexcomm::Clock::Sfro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use chip::pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use chip::pac;
 pub use chip::{peripherals, Peripherals};
-pub use embassy_hal_internal::{into_ref, Peripheral, PeripheralRef};
+pub use embassy_hal_internal::{Peri, PeripheralType};
 
 #[cfg(feature = "rt")]
 pub use crate::pac::NVIC_PRIO_BITS;

--- a/src/time_driver.rs
+++ b/src/time_driver.rs
@@ -8,7 +8,7 @@ use embassy_time_driver::Driver;
 use embassy_time_queue_utils::Queue;
 
 use crate::interrupt::InterruptExt;
-use crate::{interrupt, into_ref, pac, peripherals, Peripheral, PeripheralRef};
+use crate::{interrupt, pac, peripherals, Peri};
 
 fn rtc() -> &'static pac::rtc::RegisterBlock {
     unsafe { &*pac::Rtc::ptr() }
@@ -273,7 +273,7 @@ impl Default for Datetime {
 }
 /// Represents a real-time clock datetime.
 pub struct RtcDatetime<'r> {
-    _p: PeripheralRef<'r, peripherals::RTC>,
+    _p: Peri<'r, peripherals::RTC>,
 }
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(PartialEq)]
@@ -298,8 +298,7 @@ pub enum Error {
 /// Implementation for `RtcDatetime`.
 impl<'r> RtcDatetime<'r> {
     /// Create a new `RtcDatetime` instance.
-    pub fn new(rtc: impl Peripheral<P = peripherals::RTC> + 'r) -> Self {
-        into_ref!(rtc);
+    pub fn new(rtc: Peri<'r, peripherals::RTC>) -> Self {
         Self { _p: rtc }
     }
     /// check valid datetime.

--- a/src/wwdt.rs
+++ b/src/wwdt.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-use embassy_hal_internal::{into_ref, Peripheral};
+use embassy_hal_internal::{Peri, PeripheralType};
 
 use crate::clocks::{enable_and_reset, SysconPeripheral};
 use crate::peripherals::{WDT0, WDT1};
@@ -27,7 +27,7 @@ trait SealedInstance {
 
 /// WWDT instance trait
 #[allow(private_bounds)]
-pub trait Instance: SealedInstance + Peripheral<P = Self> + SysconPeripheral + 'static + Send {}
+pub trait Instance: SealedInstance + PeripheralType + SysconPeripheral + 'static + Send {}
 
 // Cortex-M33 watchdog
 impl SealedInstance for crate::peripherals::WDT0 {
@@ -126,9 +126,7 @@ impl<'d> WindowedWatchdog<'d> {
     ///
     /// This is not automatically cleared here because application code may wish to check
     /// if it is set via a call to [`Self::timed_out`] to determine if a watchdog reset occurred previously.
-    pub fn new<T: Instance>(_instance: impl Peripheral<P = T> + 'd, timeout_us: u32) -> Self {
-        into_ref!(_instance);
-
+    pub fn new<T: Instance>(_instance: Peri<'d, T>, timeout_us: u32) -> Self {
         let mut wwdt = Self {
             info: T::info(),
             _phantom: PhantomData,


### PR DESCRIPTION
commit d41eeeae79388f219bf6a84e2f7bde9f6b532516 in upstream embassy renamed the PeripheralRef struct to Peri and removed the Peripheral trait in favor of a new PeripheralType trait.

This commit makes sure that we can still compile our HAL with latest embassy upstream.