### PR TITLE
i2c slave: relax state machine restriction

### DIFF
--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -442,8 +442,9 @@ impl I2cSlave<'_, Async> {
         if i2c.stat().read().slvstate().is_slave_address() {
             i2c.slvctl().write(|w| w.slvcontinue().continue_());
         } else {
-            // If we are not addressed here, then we have issues.
-            return Err(TransferError::OtherBusError.into());
+            // If we are already past the addressed phase and in transmit or receive, that means we are already in the
+            // next state, most likely due to calling listen() before the previous transaction is completed and leading
+            // to state transition out of order. We can tolerate that, so we just move onto the next state.
         }
 
         // Poll for HW to transitioning from addressed to receive/transmit


### PR DESCRIPTION
This is harmless, if the slave is in the wrong state, it will just fail later, but this allows i2c slave state machine to be more robust if due to misuse of slave API, the slave is already past the addressed state.

--------------------------------------

This was exposed by an unexpectant use of the i2c slave API.

Normally we expect `respond_to_write()` to be invoked until it returns `Complete` to complete an I2C transaction, then `listen()` is invoked to wait for the next transaction.

However, in this case, due to a misunderstanding of the i2c slave API, `listen()` was invoked before `respond_to_write()` returns `Complete`. Causing the STOP for the previous i2c transaction to be interpreted as the STOP for the current ongoing transaction and thus thinking the current transaction is an 0-byte write. Completes the current transaction even though it is still in progress and stuck failing in `listen()` for all sequential transaction because it thinks it is in the addressed phase of the transaction even though it already move past the addressed phase into transmit or receive. The bug in the client code needs to be fixed: https://github.com/OpenDevicePartnership/embedded-services/issues/33. 

But there is also an opportunity to make the state machine more robust. If we relax addressed phase check, then this allows the state machine to move to the next state if it is already past the addressed phase. If the hardware is in a bad state already, it will just fail later at the end of the `listen()`.