### PR TITLE
Move waker registrations PRIOR to condition checking

### DIFF
--- a/src/dma/channel.rs
+++ b/src/dma/channel.rs
@@ -87,6 +87,7 @@ impl<'d> Channel<'d> {
             let channel = self.info.ch_num;
 
             // Has the transfer already completed?
+            // TODO: Is this necessary? We could check once after registration
             if self.info.regs.active0().read().act().bits() & (1 << channel) == 0 {
                 return Poll::Ready(());
             }

--- a/src/espi.rs
+++ b/src/espi.rs
@@ -904,10 +904,12 @@ impl<'d> Espi<'d> {
         G: FnMut(&mut Self),
     {
         poll_fn(|cx| {
+            // Register waker before checking condition, to ensure that wakes/interrupts
+            // aren't lost between f() and g()
+            ESPI_WAKER.register(cx.waker());
             let r = f(self);
 
             if r.is_pending() {
-                ESPI_WAKER.register(cx.waker());
                 g(self);
             }
 

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -791,11 +791,12 @@ impl<'a> I2cMaster<'a, Async> {
         G: FnMut(&mut Self),
     {
         poll_fn(|cx| {
+            // Register waker before checking condition, to ensure that wakes/interrupts
+            // aren't lost between f() and g()
+            I2C_WAKERS[self.info.index].register(cx.waker());
             let r = f(self);
 
             if r.is_pending() {
-                I2C_WAKERS[self.info.index].register(cx.waker());
-
                 g(self);
             }
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -102,6 +102,8 @@ impl<'d> Rng<'d> {
         // wait for interrupt
         let res = poll_fn(|cx| {
             // Check if already ready.
+            // TODO: Is this necessary? Could we just check once after
+            // the waker has been registered?
             if self.info.regs.int_status().read().ent_val().bit_is_set() {
                 return Poll::Ready(Ok(()));
             }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -646,10 +646,12 @@ impl<'a> UartTx<'a, Async> {
         G: FnMut(&mut Self),
     {
         poll_fn(|cx| {
+            // Register waker before checking condition, to ensure that wakes/interrupts
+            // aren't lost between f() and g()
+            UART_WAKERS[self.info.index].register(cx.waker());
             let r = f(self);
 
             if r.is_pending() {
-                UART_WAKERS[self.info.index].register(cx.waker());
                 g(self);
             }
 


### PR DESCRIPTION
This is a defensive move to ensure that wakes are not ever lost, if the event we are waiting for happens AFTER checking, but BEFORE (re-)registering a waker, which can happen with interrupts.

In general, "Register, then check" is the pattern that should be used to avoid potential race conditions.

There are two cases I was not sure about:

* dma::channel seems to check twice, once before and once after registering, it is likely fine to just register and then check once.
* `rng` does a slightly more complicated check, potentially not unmasking interrupts. This might also be able to be simplified.