### PR TITLE
Add I2C DMA drop guards

### DIFF
--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -508,7 +508,7 @@ impl<'a> I2cMaster<'a, Async> {
                 // Use drop guard to ensure that DMA is disabled when we exit
                 // scope, successful or not.
                 let _dma_guard = OnDrop::new(|| {
-                    i2cregs.mstctl().write(|w| w.mstdma().disabled());
+                    i2cregs.mstctl().modify(|_r, w| w.mstdma().disabled());
                 });
 
                 let res = select(
@@ -651,7 +651,7 @@ impl<'a> I2cMaster<'a, Async> {
             // Use drop guard to ensure that DMA is disabled when we exit
             // scope, successful or not.
             let dma_guard = OnDrop::new(|| {
-                i2cregs.mstctl().write(|w| w.mstdma().disabled());
+                i2cregs.mstctl().modify(|_r, w| w.mstdma().disabled());
             });
 
             let res = select(


### PR DESCRIPTION
This PR adds drop guards to disable the master/slave DMA on completion or cancellation of i2c futures.

I also added one refactor to avoid a duplicate check (and potential panicking branch, if the optimizer wasn't paying attention).