### PR TITLE
Add UART drop guards

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -770,6 +770,9 @@ impl<'a> Uart<'a, Async> {
         let tx = tx.into();
         let rx = rx.into();
 
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
         let tx_dma = dma::Dma::reserve_channel(tx_dma);
         let rx_dma = dma::Dma::reserve_channel(rx_dma);
 


### PR DESCRIPTION
Adds drop guards for UART for cancellation safety, similar to #367.

I also noticed that interrupts were never enabled when calling `Uart::new_async`, and that there were tabs in the macros, so I fixed those as well.