### PR TITLE
Fix UART CTS 

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -411,7 +411,7 @@ impl<'a, M: Mode> Uart<'a, M> {
     fn set_uart_config<T: Instance>(config: Config) {
         let regs = T::info().regs;
 
-        regs.cfg().write(|w| w.enable().disabled());
+        regs.cfg().modify(|_, w| w.enable().disabled());
 
         regs.cfg().modify(|_, w| {
             w.datalen()


### PR DESCRIPTION
set_uart_config() does a regs.cfg().write() which overwrites the regs.cfg().modify(|_, w| w.ctsen().enabled()); done earlier