### PR TITLE
Upgrade mimxrt600-fcb to 0.2.2 for the rt685 examples, as those don't work with 0.2.0 (won't boot)

### DIFF
--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "mimxrt600-fcb"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8507a7a1dd730be91a79e2b7a4af1e186a020e9bac06ff17dd760efc99f43e9c"
+checksum = "b1ebf867c0f22d440f0ad393c28d2007af23c08953b9111379dd711083ae19a9"
 dependencies = [
  "bitfield 0.15.0",
 ]

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -46,5 +46,5 @@ futures = { version = "0.3.30", default-features = false, features = [
 ] }
 embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
-mimxrt600-fcb = "0.2.0"
+mimxrt600-fcb = "0.2.2"
 rand = { version = "0.8.5", default-features = false }


### PR DESCRIPTION
Note for reviewer: perhaps the same is the case for the rt633 examples, but I have no access to that chip.