### PR TITLE
Fixed an error in seconds to datetime conversion function as well as addition of get/set functions using seconds

### DIFF
--- a/src/time_driver.rs
+++ b/src/time_driver.rs
@@ -405,7 +405,7 @@ impl<'r> RtcDatetime<'r> {
 
         let mut year = 1970;
         let mut month = 1;
-        let mut day = 0;
+        let mut day = 1;
 
         // Calculate year
         while days >= 365 {


### PR DESCRIPTION
Error in conversion using `convert_secs_to_datetime` function. Actual output is consistently off by 1 day due to erroneous initialization of `day` variable to `0` instead of `1`.

![image](https://github.com/user-attachments/assets/eb2f4b2b-62ff-4953-bab1-f39e2f55fce1)

Added functions to get and set RTC register using seconds directly for more flexibility.