### PR TITLE
Make I2C duty cycle configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embassy-executor"
 version = "0.7.0"
 source = "git+https://github.com/embassy-rs/embassy#61b77624219eac1b5e74bdeeb64f5c38df997a93"
@@ -329,6 +335,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "fixed",
+ "itertools",
  "log",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
@@ -631,6 +638,15 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "litrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ embedded-hal-nb = { version = "1.0" }
 mimxrt600-fcb = "0.2.0"
 document-features = "0.2.7"
 paste = "1.0"
+itertools = { version="0.11.0", default-features = false }
 
 # PACs
 mimxrt685s-pac = { version = "0.4.0", optional = true, features = ["rt", "critical-section"] }

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -270,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embassy-executor"
 version = "0.7.0"
 source = "git+https://github.com/embassy-rs/embassy#61b77624219eac1b5e74bdeeb64f5c38df997a93"
@@ -331,6 +337,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "fixed",
+ "itertools",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
  "mimxrt685s-pac",
@@ -675,6 +682,15 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "litrs"

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -270,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embassy-executor"
 version = "0.7.0"
 source = "git+https://github.com/embassy-rs/embassy#61b77624219eac1b5e74bdeeb64f5c38df997a93"
@@ -331,6 +337,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "fixed",
+ "itertools",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
  "mimxrt685s-pac",
@@ -699,6 +706,15 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "litrs"

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -5,7 +5,7 @@ extern crate embassy_imxrt_examples;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt::i2c::master::{I2cMaster, Speed};
+use embassy_imxrt::i2c::master::I2cMaster;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
@@ -138,7 +138,7 @@ async fn main(spawner: Spawner) {
 
     let slave = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 
-    let master = I2cMaster::new_async(p.FLEXCOMM4, p.PIO0_29, p.PIO0_30, Irqs, Speed::Standard, p.DMA0_CH9).unwrap();
+    let master = I2cMaster::new_async(p.FLEXCOMM4, p.PIO0_29, p.PIO0_30, Irqs, Default::default(), p.DMA0_CH9).unwrap();
 
     spawner.must_spawn(master_service(master));
     spawner.must_spawn(slave_service(slave));

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -5,7 +5,7 @@ extern crate embassy_imxrt_examples;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt::i2c::master::{I2cMaster, Speed};
+use embassy_imxrt::i2c::master::{DutyCycle, I2cMaster};
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
@@ -108,7 +108,11 @@ async fn main(spawner: Spawner) {
 
     let slave = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 
-    let master = I2cMaster::new_async(p.FLEXCOMM4, p.PIO0_29, p.PIO0_30, Irqs, Speed::Standard, p.DMA0_CH9).unwrap();
+    let config = i2c::master::Config {
+        speed: i2c::master::Speed::Fast,
+        duty_cycle: DutyCycle::new(50).unwrap(),
+    };
+    let master = I2cMaster::new_async(p.FLEXCOMM4, p.PIO0_29, p.PIO0_30, Irqs, config, p.DMA0_CH9).unwrap();
 
     spawner.must_spawn(master_service(master));
     spawner.must_spawn(slave_service(slave));

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -86,15 +86,9 @@ async fn main(_spawner: Spawner) {
     let _isr_pin = Input::new(p.PIO1_5, Pull::Down, Inverter::Disabled);
 
     info!("i2c example - I2c::new");
-    let mut i2c = i2c::master::I2cMaster::new_async(
-        p.FLEXCOMM2,
-        p.PIO0_18,
-        p.PIO0_17,
-        Irqs,
-        i2c::master::Speed::Standard,
-        p.DMA0_CH5,
-    )
-    .unwrap();
+    let mut i2c =
+        i2c::master::I2cMaster::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, Default::default(), p.DMA0_CH5)
+            .unwrap();
 
     info!("i2c example - write nack check");
     let result = i2c.write(NACK_ADDR, &[ACC_ID_REG]).await;

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -81,8 +81,7 @@ async fn main(_spawner: Spawner) {
     let _isr_pin = Input::new(p.PIO1_5, Pull::Down, Inverter::Disabled);
 
     info!("i2c example - I2c::new");
-    let mut i2c =
-        i2c::master::I2cMaster::new_blocking(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, i2c::master::Speed::Standard).unwrap();
+    let mut i2c = i2c::master::I2cMaster::new_blocking(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Default::default()).unwrap();
 
     // Read WHO_AM_I register, 0x0D to get value 0xC7 (1100 0111)
     info!("i2c example - ACC WHO_AM_I register check");

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -92,9 +92,7 @@ impl<'a, M: Mode> I2cMaster<'a, M> {
             // SAFETY: only unsafe due to .bits usage
             unsafe { w.mstsclhigh().bits(0).mstscllow().bits(1) });
 
-        regs.intenset().write(|w|
-                // SAFETY: only unsafe due to .bits usage
-                unsafe { w.bits(0) });
+        regs.intenset().reset();
 
         regs.cfg().write(|w| w.msten().set_bit());
 

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -6,6 +6,7 @@ use core::task::Poll;
 
 use embassy_futures::select::{select, Either};
 use embassy_hal_internal::drop::OnDrop;
+use itertools::Itertools;
 
 use super::{
     force_clear_remediation, wait_remediation_complete, Async, Blocking, Error, Info, Instance, InterruptHandler,
@@ -14,9 +15,11 @@ use super::{
 };
 use crate::flexcomm::FlexcommRef;
 use crate::interrupt::typelevel::Interrupt;
+use crate::pac::i2c0::msttime::{Mstsclhigh, Mstscllow};
 use crate::{dma, interrupt, Peri};
 
 /// Bus speed (nominal SCL, no clock stretching)
+#[derive(Clone, Copy)]
 pub enum Speed {
     /// 100 kbit/s
     Standard,
@@ -31,6 +34,119 @@ pub enum Speed {
     High,
 }
 
+/// Divide integers rounding to the nearest whole number rather than always down
+fn rounded_divide(numerator: u32, denominator: u32) -> u32 {
+    (numerator + denominator / 2) / denominator
+}
+
+fn get_duty_cycle(hi_clocks: u8, lo_clocks: u8) -> u8 {
+    let total_clocks = u16::from(hi_clocks + lo_clocks);
+    (100 * u16::from(hi_clocks) / total_clocks) as u8
+}
+
+fn get_freq_hz(hi_clocks: u8, lo_clocks: u8, clock_div_multiplier: u16, clock_speed_hz: u32) -> u32 {
+    clock_speed_hz / (u32::from(hi_clocks + lo_clocks) * u32::from(clock_div_multiplier))
+}
+
+// We need to be able to convert back to the clocks representation, but can't implement From/Into because
+// neither the type nor the trait are defined in our crate.  Therefore, we define this Into-like trait and
+// use that instead.
+//
+trait IntoClocksEnum<DestT> {
+    fn into_clocks_enum(&self) -> DestT;
+}
+
+const MIN_CLOCKS: u8 = 2;
+const MAX_CLOCKS: u8 = 9;
+
+impl IntoClocksEnum<Mstscllow> for u8 {
+    fn into_clocks_enum(&self) -> Mstscllow {
+        match *self {
+            2 => Mstscllow::Clocks2,
+            3 => Mstscllow::Clocks3,
+            4 => Mstscllow::Clocks4,
+            5 => Mstscllow::Clocks5,
+            6 => Mstscllow::Clocks6,
+            7 => Mstscllow::Clocks7,
+            8 => Mstscllow::Clocks8,
+            9 => Mstscllow::Clocks9,
+            _ => panic!("Invalid value for Mstscllow"),
+        }
+    }
+}
+
+impl IntoClocksEnum<Mstsclhigh> for u8 {
+    fn into_clocks_enum(&self) -> Mstsclhigh {
+        match *self {
+            2 => Mstsclhigh::Clocks2,
+            3 => Mstsclhigh::Clocks3,
+            4 => Mstsclhigh::Clocks4,
+            5 => Mstsclhigh::Clocks5,
+            6 => Mstsclhigh::Clocks6,
+            7 => Mstsclhigh::Clocks7,
+            8 => Mstsclhigh::Clocks8,
+            9 => Mstsclhigh::Clocks9,
+            _ => panic!("Invalid value for Mstsclhigh"),
+        }
+    }
+}
+
+struct SpeedRegisterSettings {
+    scl_high_clocks: Mstsclhigh,
+    scl_low_clocks: Mstscllow,
+    clock_div_multiplier: u16,
+
+    _actual_freq_hz: u32,
+}
+
+impl SpeedRegisterSettings {
+    fn new(duty_cycle: DutyCycle, speed: Speed) -> Result<Self> {
+        const SFRO_CLOCK_SPEED_HZ: u32 = 16_000_000;
+
+        let target_freq_hz: u32 = match speed {
+            Speed::Standard => 100_000,   // 100 KHz
+            Speed::Fast => 400_000,       // 400 KHz
+            Speed::FastPlus => 1_000_000, // 1 MHz
+
+            _ => return Err(Error::UnsupportedConfiguration),
+        };
+
+        // Figure out what we need to set the clock divider to in order to hit the I2C speed the user requested.  Again, we may not
+        // be able to be exact, so we need to find the closest viable option.
+        //
+        let (result_clocks_hi, result_clocks_lo, result_div_multiplier) = (MIN_CLOCKS..=MAX_CLOCKS)
+            .cartesian_product(MIN_CLOCKS..=MAX_CLOCKS)
+            .filter(|(hi_clocks, lo_clocks)| get_duty_cycle(*hi_clocks, *lo_clocks) == duty_cycle.value)
+            .map(|(hi_clocks, lo_clocks)| {
+                // As speeds increase, clock_div_multiplier will approach 1, so rounding to the nearest whole number (rather than always down
+                // as normal integer division does) can meaningfully reduce error in the actual speed in cases where the remainder is high.
+                let clock_div_multiplier =
+                    rounded_divide(SFRO_CLOCK_SPEED_HZ, target_freq_hz * u32::from(hi_clocks + lo_clocks)) as u16;
+                (hi_clocks, lo_clocks, clock_div_multiplier)
+            })
+            .min_by(|a, b| {
+                let (hi_a, lo_a, div_a) = a;
+                let (hi_b, lo_b, div_b) = b;
+                let freq_a = get_freq_hz(*hi_a, *lo_a, *div_a, SFRO_CLOCK_SPEED_HZ);
+                let freq_b = get_freq_hz(*hi_b, *lo_b, *div_b, SFRO_CLOCK_SPEED_HZ);
+
+                target_freq_hz.abs_diff(freq_a).cmp(&target_freq_hz.abs_diff(freq_b))
+            })
+            .ok_or(Error::UnsupportedConfiguration)?;
+
+        // A clock divider of 1 means 'divide clocks by 2', not 'divide clocks by 1', so we need to account for that.
+        //
+        const CLOCK_DIV_MULTIPLIER_OFFSET: u16 = 1;
+        Ok(Self {
+            scl_high_clocks: result_clocks_hi.into_clocks_enum(),
+            scl_low_clocks: result_clocks_lo.into_clocks_enum(),
+            clock_div_multiplier: result_div_multiplier - CLOCK_DIV_MULTIPLIER_OFFSET,
+            _actual_freq_hz: SFRO_CLOCK_SPEED_HZ
+                / (u32::from(result_clocks_hi + result_clocks_lo) * u32::from(result_div_multiplier)),
+        })
+    }
+}
+
 /// use `FCn` as I2C Master controller
 pub struct I2cMaster<'a, M: Mode> {
     info: Info,
@@ -39,13 +155,78 @@ pub struct I2cMaster<'a, M: Mode> {
     dma_ch: Option<dma::channel::Channel<'a>>,
 }
 
+/// Represents a duty cycle (percentage of time to hold the SCL line high per bit).  Fitting is best-effort / not exact.
+#[derive(Clone, Copy)]
+pub struct DutyCycle {
+    value: u8,
+}
+
+impl DutyCycle {
+    /// Determines and represents the closest possible duty cycle to the requested duty cycle that the hardware can support.
+    pub fn new(target_duty_cycle: u8) -> Result<Self> {
+        if target_duty_cycle < 100 * MIN_CLOCKS / (MIN_CLOCKS + MAX_CLOCKS)
+            || target_duty_cycle > (100 * MAX_CLOCKS as u16 / (MIN_CLOCKS + MAX_CLOCKS) as u16 + 1) as u8
+        {
+            Err(Error::UnsupportedConfiguration)
+        } else {
+            // The hardware only has 6 bits of configurability for duty cycle and some of those represent duplicate duty cycles,
+            // so we may not be able to accommodate the exact duty cycle the user has requested.  We need to find the closest
+            // viable option.
+            //
+            let closest_supported_duty_cycle = (MIN_CLOCKS..=MAX_CLOCKS)
+                .cartesian_product(MIN_CLOCKS..=MAX_CLOCKS)
+                .map(|(hi_clocks, lo_clocks)| get_duty_cycle(hi_clocks, lo_clocks))
+                .min_by(|duty_cycle_a, duty_cycle_b| {
+                    duty_cycle_a
+                        .abs_diff(target_duty_cycle)
+                        .cmp(&duty_cycle_b.abs_diff(target_duty_cycle))
+                })
+                .ok_or(Error::UnsupportedConfiguration)?;
+
+            Ok(Self {
+                value: closest_supported_duty_cycle,
+            })
+        }
+    }
+
+    /// Retreives the actual selected duty cycle, which may be slightly different from the requested duty cycle due to hardware limitations.
+    pub fn actual_value(&self) -> u8 {
+        self.value
+    }
+}
+
+impl Default for DutyCycle {
+    fn default() -> Self {
+        DutyCycle::new(40).unwrap()
+    }
+}
+
+/// Configuration for I2C Master
+#[derive(Clone, Copy)]
+pub struct Config {
+    /// Bus speed (nominal SCL, no clock stretching)
+    pub speed: Speed,
+
+    /// The target duty cycle (percentage of time to hold the SCL line high per bit).
+    pub duty_cycle: DutyCycle,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            speed: Speed::Standard,
+            duty_cycle: Default::default(),
+        }
+    }
+}
+
 impl<'a, M: Mode> I2cMaster<'a, M> {
     fn new_inner<T: Instance>(
         _bus: Peri<'a, T>,
         scl: Peri<'a, impl SclPin<T>>,
         sda: Peri<'a, impl SdaPin<T>>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        speed: Speed,
+        config: Config,
         dma_ch: Option<dma::channel::Channel<'a>>,
     ) -> Result<Self> {
         // TODO - clock integration
@@ -59,38 +240,19 @@ impl<'a, M: Mode> I2cMaster<'a, M> {
         let info = T::info();
         let regs = info.regs;
 
-        // this check should be redundant with T::set_mode()? above
+        let speed_settings = SpeedRegisterSettings::new(config.duty_cycle, config.speed)?;
 
-        // rates taken assuming SFRO:
-        //
-        //  7 => 403.3 kHz
-        //  9 => 322.6 kHz
-        // 12 => 247.8 kHz
-        // 16 => 198.2 kHz
-        // 18 => 166.6 Khz
-        // 22 => 142.6 kHz
-        // 30 => 100.0 kHz
-        match speed {
-            // 100 kHz
-            Speed::Standard => {
-                regs.clkdiv().write(|w|
-                // SAFETY: only unsafe due to .bits usage
-                unsafe { w.divval().bits(30) });
-            }
+        regs.msttime().write(|w| {
+            w.mstsclhigh()
+                .variant(speed_settings.scl_high_clocks)
+                .mstscllow()
+                .variant(speed_settings.scl_low_clocks)
+        });
 
-            // 400 kHz
-            Speed::Fast => {
-                regs.clkdiv().write(|w|
-                // SAFETY: only unsafe due to .bits usage
-                unsafe { w.divval().bits(7) });
-            }
-
-            _ => return Err(Error::UnsupportedConfiguration),
-        }
-
-        regs.msttime().write(|w|
-            // SAFETY: only unsafe due to .bits usage
-            unsafe { w.mstsclhigh().bits(0).mstscllow().bits(1) });
+        regs.clkdiv().write(|w| {
+            // SAFETY: only unsafe due to .bits usage.
+            unsafe { w.divval().bits(speed_settings.clock_div_multiplier) }
+        });
 
         regs.intenset().reset();
 
@@ -124,10 +286,10 @@ impl<'a> I2cMaster<'a, Blocking> {
         scl: Peri<'a, impl SclPin<T>>,
         sda: Peri<'a, impl SdaPin<T>>,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        speed: Speed,
+        config: Config,
     ) -> Result<Self> {
         force_clear_remediation(&T::info());
-        Ok(Self::new_inner::<T>(fc, scl, sda, speed, None)?)
+        Ok(Self::new_inner::<T>(fc, scl, sda, config, None)?)
     }
 
     fn start(&mut self, address: u16, is_read: bool) -> Result<()> {
@@ -319,12 +481,12 @@ impl<'a> I2cMaster<'a, Async> {
         sda: Peri<'a, impl SdaPin<T>>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'a,
         // TODO - integrate clock APIs to allow dynamic freq selection | clock: crate::flexcomm::Clock,
-        speed: Speed,
+        config: Config,
         dma_ch: Peri<'a, impl MasterDma<T>>,
     ) -> Result<Self> {
         force_clear_remediation(&T::info());
         let ch = dma::Dma::reserve_channel(dma_ch);
-        let this = Self::new_inner::<T>(fc, scl, sda, speed, ch)?;
+        let this = Self::new_inner::<T>(fc, scl, sda, config, ch)?;
 
         T::Interrupt::unpend();
         unsafe { T::Interrupt::enable() };

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -21,21 +21,6 @@ pub mod slave;
 /// shorthand for -> `Result<T>`
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Bus speed (nominal SCL, no clock stretching)
-pub enum Speed {
-    /// 100 kbit/s
-    Standard,
-
-    /// 400 kbit/s
-    Fast,
-
-    /// 1 Mbit/s
-    FastPlus,
-
-    /// 3.4Mbit/s only available for slave devices
-    High,
-}
-
 /// specific information regarding transfer errors
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -205,6 +205,10 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.itertools]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.lock_api]]
 version = "0.4.12"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -142,6 +142,34 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.either]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.0"
+notes = "Unsafe code pertaining to wrapping Pin APIs. Mostly passes invariants down."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.0 -> 1.14.0"
+notes = """
+Inheriting ub-risk-1 from the baseline review of 1.13.0. While the delta has some diffs in unsafe code, they are either:
+- migrating code to use helper macros
+- migrating match patterns to take advantage of default bindings mode from RFC 2005
+Either way, the result is code that does exactly the same thing and does not change the risk of UB.
+
+See https://crrev.com/c/6323164 for more audit details.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.0"
+notes = "The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = \"std\")]`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.nb]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This change enables configuring the duty cycle for the I2C bus by specifying the number of clock cycles that the clock line will be asserted high/low by the I2C master device

Closes #267 