### PR TITLE
Avoid vetting embassy dependencies pulled from GitHub

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -11,31 +11,31 @@ url = "https://raw.githubusercontent.com/google/rust-crate-audits/main/audits.to
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
 [policy.embassy-executor]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-executor-macros]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-futures]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-hal-internal]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-imxrt]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-sync]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-time]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-time-driver]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.embassy-time-queue-utils]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [[exemptions.atomic-polyfill]]
 version = "1.0.3"
@@ -127,42 +127,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.defmt-parser]]
 version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor]]
-version = "0.7.0@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor-macros]]
-version = "0.6.2@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-futures]]
-version = "0.1.1@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-hal-internal]]
-version = "0.2.0@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-imxrt]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-sync]]
-version = "0.6.2@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time]]
-version = "0.4.0@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time-driver]]
-version = "0.2.0@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time-queue-utils]]
-version = "0.1.0@git:61b77624219eac1b5e74bdeeb64f5c38df997a93"
 criteria = "safe-to-deploy"
 
 [[exemptions.embedded-hal]]


### PR DESCRIPTION
Description copied from https://github.com/OpenDevicePartnership/embedded-services/pull/246
Exactly applicable to this repository as well.

`cargo vet` is primarily to audit third party dependencies from crates.io
Since embassy crates are also published on crates.io but we're using the GitHub versions, this leads to some issues.

If we mark them to have the same audit criteria as applied to other crates `audit-as-crates-io = true`, it would mean that we need to audit new versions of the dependencies every time cargo.lock is updated, which is pretty frequent for a GitHub based dependency as it uses the commit hash of the HEAD.

![image](https://github.com/user-attachments/assets/662ea580-ca41-4b91-97ba-eafcc99e382c)


If we don't include them in config.toml, it results in a vet failure as matches are found on crates.io, but they don't match with what we're using.

![image](https://github.com/user-attachments/assets/0108ec5b-27e4-4058-a832-37902d44f0c3)


The alternative is to mark them as not from crates.io, which is what this PR does.
We mark them as `audit-as-crates-io = false`, which is meant to be used for first party dependencies to declare them as inherently vetted, but seems to be the best option in this case.

As we move to using the published versions from crates.io, this would need to be updated again.