### PR TITLE
Temporarily suppress deprecation warning for RUSTSEC-2023-0089

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2024-0436", reason = "there are no suitable replacements for paste right now; paste has been archived as read-only. It only affects compile time concatenation in macros. We will allow it for now" },
+    { id = "RUSTSEC-2023-0089", reason = "this is a deprecation warning for a dependency of a dependency. https://github.com/jamesmunns/postcard/issues/223 tracks fixing the dependency; until that's resolved, we can accept the deprecated code as it has no known vulnerabilities."}
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
A new security advisory was posted this morning for the atomic-polyfill crate, which is now unmaintained, with the authors suggesting to switch to using portable-atomic instead.  It looks like we don't have a direct dependency on atomic-polyfill, though - rather, we have this dependency chain:

+ atomic-polyfill v1.0.3
 +-- heapless v0.7.17
  +-- postcard v1.1.1
   +-- embedded-services v0.1.0
    +-- storage_bus v0.1.1
      +-- embassy-imxrt v0.1.0

It looks like there's already a new version of heapless (0.8.0) that has made the switch, but postcard has not been updated to consume it yet because it's a breaking change.  It sounds like the author of postcard is aware of the issue as of today and is looking into a fix (https://github.com/jamesmunns/postcard/issues/223)

Until then, our gates are broken on this, so we're suppressing the warning until a new version of postcard is available. This should be low risk because the security advisory is just that the project is unmaintained, not that it has an actual vulnerability.  We can revert this when the new version of postcard is available.