### PR TITLE
Fix build for rtc-time example

### DIFF
--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -32,7 +32,7 @@ async fn main(_spawner: Spawner) {
     Timer::after_millis(20000).await;
 
     // get the datetime set and compare
-    let (time, result) = r.get_datetime();
+    let result = r.get_datetime();
     assert!(result.is_ok());
-    info!("RTC get time: {:?}", time);
+    info!("RTC get time: {:?}", result.unwrap());
 }

--- a/src/time_driver.rs
+++ b/src/time_driver.rs
@@ -276,7 +276,7 @@ pub struct RtcDatetime<'r> {
     _p: Peri<'r, peripherals::RTC>,
 }
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 /// Represents the result of a datetime validation.
 pub enum Error {
     /// The year is invalid.


### PR DESCRIPTION
Commit 8f9b05cd2688eae443473cfd6fce6897fcd06475 changed the return type of RtcDatetime::get_datetime() from (Datetime, Result<(), Error>) to Result<Datetime, Error>, but it missed the example that leverages get_datetime. This change fixes the example so it compiles and derives Debug for the error type so that Result::unwrap() can be used.