### PR TITLE
update msrv in rolling.yml to match check.yml

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.83"] # We're relying on namespaced-features, which
+        msrv: ["1.85"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -51,6 +51,9 @@ jobs:
                        # collapse_debuginfo
                        #
                        # embassy upstream switched to rust 1.83
+                       #
+                       # embedded-services (storage bus) dependency
+                       # requires 1.85
     name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Rolling builds keep failing at the `cargo check` stage due to a mismatch in msrv between embassy-imxrt and embedded-services.
https://github.com/OpenDevicePartnership/embassy-imxrt/actions/runs/14743792940/job/41387199568

Check.yml has the correct 1.85 version, this PR updates the msrv in rolling.yml