### PR TITLE
Move cargo-hack to a script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -128,53 +128,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        feature: [ "mimxrt633s", "mimxrt633s,rt", "mimxrt633s,defmt",
-          "mimxrt633s,time", "mimxrt633s,time-driver-os-timer",
-          "mimxrt633s,unstable-pac", "mimxrt633s,rt,defmt",
-          "mimxrt633s,rt,time", "mimxrt633s,rt,time-driver-os-timer",
-          "mimxrt633s,rt,unstable-pac", "mimxrt633s,defmt,time",
-          "mimxrt633s,defmt,time-driver-os-timer", "mimxrt633s,defmt,unstable-pac",
-          "mimxrt633s,time,time-driver-os-timer", "mimxrt633s,time,unstable-pac",
-          "mimxrt633s,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,rt,defmt,time", "mimxrt633s,rt,defmt,time-driver-os-timer",
-          "mimxrt633s,rt,defmt,unstable-pac",
-          "mimxrt633s,rt,time,time-driver-os-timer",
-          "mimxrt633s,rt,time,unstable-pac",
-          "mimxrt633s,rt,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,defmt,time,time-driver-os-timer",
-          "mimxrt633s,defmt,time,unstable-pac",
-          "mimxrt633s,defmt,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,time,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,rt,defmt,time,time-driver-os-timer",
-          "mimxrt633s,rt,defmt,time,unstable-pac",
-          "mimxrt633s,rt,defmt,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,rt,time,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,defmt,time,time-driver-os-timer,unstable-pac",
-          "mimxrt633s,rt,defmt,time,time-driver-os-timer,unstable-pac",
-          "mimxrt685s", "mimxrt685s,rt", "mimxrt685s,defmt",
-          "mimxrt685s,time", "mimxrt685s,time-driver-os-timer",
-          "mimxrt685s,unstable-pac", "mimxrt685s,rt,defmt",
-          "mimxrt685s,rt,time", "mimxrt685s,rt,time-driver-os-timer",
-          "mimxrt685s,rt,unstable-pac", "mimxrt685s,defmt,time",
-          "mimxrt685s,defmt,time-driver-os-timer", "mimxrt685s,defmt,unstable-pac",
-          "mimxrt685s,time,time-driver-os-timer", "mimxrt685s,time,unstable-pac",
-          "mimxrt685s,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,rt,defmt,time", "mimxrt685s,rt,defmt,time-driver-os-timer",
-          "mimxrt685s,rt,defmt,unstable-pac",
-          "mimxrt685s,rt,time,time-driver-os-timer",
-          "mimxrt685s,rt,time,unstable-pac",
-          "mimxrt685s,rt,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,defmt,time,time-driver-os-timer",
-          "mimxrt685s,defmt,time,unstable-pac",
-          "mimxrt685s,defmt,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,time,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,rt,defmt,time,time-driver-os-timer",
-          "mimxrt685s,rt,defmt,time,unstable-pac",
-          "mimxrt685s,rt,defmt,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,rt,time,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,defmt,time,time-driver-os-timer,unstable-pac",
-          "mimxrt685s,rt,defmt,time,time-driver-os-timer,unstable-pac" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -184,13 +137,14 @@ jobs:
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: cargo install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+      - name: rustup target add thumbv8m.main-none-eabihf
+        run: rustup target add thumbv8m.main-none-eabihf
 
-      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
-      # --feature-powerset runs for every combination of features
+      - name: cargo install cargo-batch
+        run: cargo install --git https://github.com/embassy-rs/cargo-batch cargo --bin cargo-batch --locked
+
       - name: cargo manual hack
-        run: cargo check -F ${{ matrix.feature }} --locked
+        run: ./ci.sh
 
   deny:
     # cargo-deny checks licenses, advisories, sources, and bans for

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if ! command -v cargo-batch &> /dev/null; then
+    echo "cargo-batch could not be found. Install it with the following command:"
+    echo ""
+    echo "    cargo install --git https://github.com/embassy-rs/cargo-batch cargo --bin cargo-batch --locked"
+    echo ""
+    exit 1
+fi
+
+export RUSTFLAGS=-Dwarnings
+export DEFMT_LOG=trace,embassy_hal_internal=debug
+if [[ -z "${CARGO_TARGET_DIR}" ]]; then
+    export CARGO_TARGET_DIR=target_ci
+fi
+
+TARGET="thumbv8m.main-none-eabihf"
+
+BUILD_EXTRA=""
+
+cargo batch \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,defmt,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,defmt,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,rt,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt633s,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,defmt,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,defmt,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,rt,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time-driver-os-timer \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time-driver-os-timer,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time-driver-rtc \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,time-driver-rtc,unstable-pac \
+      --- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features mimxrt685s,unstable-pac \
+      $BUILD_EXTRA


### PR DESCRIPTION
CI was starting to limit the amount of variations we could run in cargo hack. Instead, let's make a script that runs within CI and relies on cargo-batch to run all variations.

While at that, also make sure to add RTC timer as a variant.