### PR TITLE
Improve teaching value of examples

### DIFF
--- a/examples/rt633/src/bin/espi.rs
+++ b/examples/rt633/src/bin/espi.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-use rt633_examples as _;
-
 use core::slice;
 
 use defmt::{error, info};
@@ -13,7 +11,7 @@ use embassy_imxrt::espi::{
     PortConfig,
 };
 use embassy_imxrt::peripherals::ESPI;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, panic_probe as _, rt633_examples as _};
 
 bind_interrupts!(struct Irqs {
     ESPI => InterruptHandler<ESPI>;

--- a/examples/rt633/src/bin/espi.rs
+++ b/examples/rt633/src/bin/espi.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate rt633_examples;
+use rt633_examples as _;
 
 use core::slice;
 

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "mimxrt633s-pac"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1edd8317cebedee09f61910c2a5612576254367b1ca74375ee987b4db20df2"
+checksum = "843c1c63c367293e4fa270cc161b5bdfef55b4c6a0a18768f737241fb24be70c"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/examples/rt685s-evk/src/bin/adc.rs
+++ b/examples/rt685s-evk/src/bin/adc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/adc.rs
+++ b/examples/rt685s-evk/src/bin/adc.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::adc::{Adc, ChannelConfig, Config, InterruptHandler};
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     ADC0 => InterruptHandler<peripherals::ADC0>;

--- a/examples/rt685s-evk/src/bin/adc.rs
+++ b/examples/rt685s-evk/src/bin/adc.rs
@@ -8,6 +8,7 @@ use embassy_executor::Spawner;
 use embassy_imxrt::adc::{Adc, ChannelConfig, Config, InterruptHandler};
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     ADC0 => InterruptHandler<peripherals::ADC0>;

--- a/examples/rt685s-evk/src/bin/benchmarking-gpio.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-gpio.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/benchmarking-gpio.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-gpio.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use defmt_rtt as _;

--- a/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
@@ -4,9 +4,9 @@
 use embassy_imxrt_examples as _;
 
 use defmt::info;
-use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/clocks-blinky.rs
+++ b/examples/rt685s-evk/src/bin/clocks-blinky.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::{error, info};
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/clocks-blinky.rs
+++ b/examples/rt685s-evk/src/bin/clocks-blinky.rs
@@ -1,14 +1,12 @@
 #![no_main]
 #![no_std]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_imxrt::iopctl::IopctlPin;
 use embassy_imxrt::{clocks, gpio};
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/crc.rs
+++ b/examples/rt685s-evk/src/bin/crc.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use embassy_executor::Spawner;
 use embassy_imxrt::crc::{Config, Crc, Polynomial};
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/crc.rs
+++ b/examples/rt685s-evk/src/bin/crc.rs
@@ -3,7 +3,6 @@
 
 use embassy_imxrt_examples as _;
 
-use defmt::*;
 use embassy_executor::Spawner;
 use embassy_imxrt::crc::{Config, Crc, Polynomial};
 use {defmt_rtt as _, panic_probe as _};
@@ -13,7 +12,7 @@ async fn main(_spawner: Spawner) {
     let mut p = embassy_imxrt::init(Default::default());
     let data = b"123456789";
 
-    info!("Initializing CRC");
+    defmt::info!("Initializing CRC");
 
     // CRC-CCITT
     let mut crc = Crc::new(p.CRC.reborrow(), Default::default());

--- a/examples/rt685s-evk/src/bin/crc.rs
+++ b/examples/rt685s-evk/src/bin/crc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::*;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -5,21 +5,15 @@ use embassy_imxrt_examples as _;
 
 use defmt::{info, error};
 use embassy_executor::Spawner;
-use embassy_imxrt::dma::channel::Channel;
 use embassy_imxrt::dma::transfer::{Priority, Transfer, TransferOptions, Width};
 use embassy_imxrt::dma::Dma;
+use embassy_imxrt::Peri;
 use {defmt_rtt as _, panic_probe as _};
 
 const TEST_LEN: usize = 16;
 
-macro_rules! test_dma_channel {
-    ($peripherals:expr, $instance:ident, $number:expr) => {
-        let ch = Dma::reserve_channel($peripherals.$instance).unwrap();
-        dma_test(ch, $number).await;
-    };
-}
-
-async fn dma_test(ch: Channel<'static>, number: usize) {
+async fn dma_test<DMA: embassy_imxrt::dma::Instance>(peripheral: Peri<'_, DMA>, number: usize) {
+    let ch = Dma::reserve_channel(peripheral).unwrap();
     for width in [Width::Bit8, Width::Bit16, Width::Bit32] {
         let mut srcbuf: [u8; TEST_LEN] = [0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
         let mut dstbuf = [0u8; TEST_LEN];
@@ -54,38 +48,38 @@ async fn main(_spawner: Spawner) {
 
     info!("Test memory-to-memory DMA transfers");
 
-    test_dma_channel!(p, DMA0_CH0, 0);
-    test_dma_channel!(p, DMA0_CH1, 1);
-    test_dma_channel!(p, DMA0_CH2, 2);
-    test_dma_channel!(p, DMA0_CH3, 3);
-    test_dma_channel!(p, DMA0_CH4, 4);
-    test_dma_channel!(p, DMA0_CH5, 5);
-    test_dma_channel!(p, DMA0_CH6, 6);
-    test_dma_channel!(p, DMA0_CH7, 7);
-    test_dma_channel!(p, DMA0_CH8, 8);
-    test_dma_channel!(p, DMA0_CH9, 9);
-    test_dma_channel!(p, DMA0_CH10, 10);
-    test_dma_channel!(p, DMA0_CH11, 11);
-    test_dma_channel!(p, DMA0_CH12, 12);
-    test_dma_channel!(p, DMA0_CH13, 13);
-    test_dma_channel!(p, DMA0_CH14, 14);
-    test_dma_channel!(p, DMA0_CH15, 15);
-    test_dma_channel!(p, DMA0_CH16, 16);
-    test_dma_channel!(p, DMA0_CH17, 17);
-    test_dma_channel!(p, DMA0_CH18, 18);
-    test_dma_channel!(p, DMA0_CH19, 19);
-    test_dma_channel!(p, DMA0_CH20, 20);
-    test_dma_channel!(p, DMA0_CH21, 21);
-    test_dma_channel!(p, DMA0_CH22, 22);
-    test_dma_channel!(p, DMA0_CH23, 23);
-    test_dma_channel!(p, DMA0_CH24, 24);
-    test_dma_channel!(p, DMA0_CH25, 25);
-    test_dma_channel!(p, DMA0_CH26, 26);
-    test_dma_channel!(p, DMA0_CH27, 27);
-    test_dma_channel!(p, DMA0_CH28, 28);
-    test_dma_channel!(p, DMA0_CH29, 29);
-    test_dma_channel!(p, DMA0_CH30, 30);
-    test_dma_channel!(p, DMA0_CH31, 31);
+    dma_test(p.DMA0_CH0, 0).await;
+    dma_test(p.DMA0_CH1, 1).await;
+    dma_test(p.DMA0_CH2, 2).await;
+    dma_test(p.DMA0_CH3, 3).await;
+    dma_test(p.DMA0_CH4, 4).await;
+    dma_test(p.DMA0_CH5, 5).await;
+    dma_test(p.DMA0_CH6, 6).await;
+    dma_test(p.DMA0_CH7, 7).await;
+    dma_test(p.DMA0_CH8, 8).await;
+    dma_test(p.DMA0_CH9, 9).await;
+    dma_test(p.DMA0_CH10, 10).await;
+    dma_test(p.DMA0_CH11, 11).await;
+    dma_test(p.DMA0_CH12, 12).await;
+    dma_test(p.DMA0_CH13, 13).await;
+    dma_test(p.DMA0_CH14, 14).await;
+    dma_test(p.DMA0_CH15, 15).await;
+    dma_test(p.DMA0_CH16, 16).await;
+    dma_test(p.DMA0_CH17, 17).await;
+    dma_test(p.DMA0_CH18, 18).await;
+    dma_test(p.DMA0_CH19, 19).await;
+    dma_test(p.DMA0_CH20, 20).await;
+    dma_test(p.DMA0_CH21, 21).await;
+    dma_test(p.DMA0_CH22, 22).await;
+    dma_test(p.DMA0_CH23, 23).await;
+    dma_test(p.DMA0_CH24, 24).await;
+    dma_test(p.DMA0_CH25, 25).await;
+    dma_test(p.DMA0_CH26, 26).await;
+    dma_test(p.DMA0_CH27, 27).await;
+    dma_test(p.DMA0_CH28, 28).await;
+    dma_test(p.DMA0_CH29, 29).await;
+    dma_test(p.DMA0_CH30, 30).await;
+    dma_test(p.DMA0_CH31, 31).await;
 
     info!("DMA transfer tests completed");
 }

--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -3,19 +3,18 @@
 
 use embassy_imxrt_examples as _;
 
-use defmt::*;
+use defmt::{info, error};
 use embassy_executor::Spawner;
 use embassy_imxrt::dma::channel::Channel;
 use embassy_imxrt::dma::transfer::{Priority, Transfer, TransferOptions, Width};
 use embassy_imxrt::dma::Dma;
-use embassy_imxrt::peripherals::*;
 use {defmt_rtt as _, panic_probe as _};
 
 const TEST_LEN: usize = 16;
 
 macro_rules! test_dma_channel {
     ($peripherals:expr, $instance:ident, $number:expr) => {
-        let ch = Dma::reserve_channel::<$instance>($peripherals.$instance).unwrap();
+        let ch = Dma::reserve_channel($peripherals.$instance).unwrap();
         dma_test(ch, $number).await;
     };
 }

--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
-use defmt::{info, error};
+use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_imxrt::dma::transfer::{Priority, Transfer, TransferOptions, Width};
 use embassy_imxrt::dma::Dma;
 use embassy_imxrt::Peri;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const TEST_LEN: usize = 16;
 

--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use embassy_imxrt_examples as _;
+
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_imxrt::dma::channel::Channel;

--- a/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
+++ b/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
@@ -30,7 +30,8 @@ mod sealed {
     pub trait Sealed {}
 }
 
-impl<T> sealed::Sealed for T {}
+impl sealed::Sealed for Blocking {}
+impl sealed::Sealed for Async {}
 
 /// Driver mode.
 #[allow(private_bounds)]

--- a/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
+++ b/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
@@ -7,12 +7,12 @@ use embassy_imxrt::flexspi::nor::{
     AhbConfig, FlexSpiFlashPort, FlexSpiFlashPortDeviceInstance, FlexspiAhbBufferConfig, FlexspiConfig,
     FlexspiConfigPortData, FlexspiDeviceConfig, FlexspiNorStorageBus,
 };
-use embassy_imxrt::pac::flexspi::ahbcr::*;
-use embassy_imxrt::pac::flexspi::flshcr1::*;
-use embassy_imxrt::pac::flexspi::flshcr2::*;
-use embassy_imxrt::pac::flexspi::flshcr4::*;
-use embassy_imxrt::pac::flexspi::mcr0::*;
-use embassy_imxrt::pac::flexspi::mcr2::*;
+use embassy_imxrt::pac::flexspi::ahbcr::{Bufferableen, Cachableen, Readaddropt};
+use embassy_imxrt::pac::flexspi::flshcr1::Csintervalunit;
+use embassy_imxrt::pac::flexspi::flshcr2::Awrwaitunit;
+use embassy_imxrt::pac::flexspi::flshcr4::{Wmena, Wmenb};
+use embassy_imxrt::pac::flexspi::mcr0::{Dozeen, Hsen, Rxclksrc, Sckfreerunen};
+use embassy_imxrt::pac::flexspi::mcr2::{Clrahbbufopt, Samedeviceen, Sckbdiffopt};
 use embassy_time::Timer;
 use embedded_storage::nor_flash::{
     ErrorType, NorFlash as BlockingNorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash as BlockingReadNorFlash,

--- a/examples/rt685s-evk/src/bin/gpio-async-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-async-input.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::debug;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::{Duration, Ticker};
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::task]
 async fn monitor_task(mut monitor: gpio::Input<'static>) {

--- a/examples/rt685s-evk/src/bin/gpio-async-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-async-input.rs
@@ -3,7 +3,7 @@
 
 use embassy_imxrt_examples as _;
 
-use defmt::*;
+use defmt::debug;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::{Duration, Ticker};

--- a/examples/rt685s-evk/src/bin/gpio-async-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-async-input.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::*;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -7,6 +7,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::{assert, info};
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -8,6 +8,7 @@ use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_imxrt::gpio::SenseDisabled;
 use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{assert, info};
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_imxrt::gpio::SenseDisabled;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-input.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/gpio-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-input.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-input.rs
@@ -7,6 +7,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/hello-world.rs
+++ b/examples/rt685s-evk/src/bin/hello-world.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/hello-world.rs
+++ b/examples/rt685s-evk/src/bin/hello-world.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -10,6 +10,7 @@ use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embedded_hal_async::i2c::I2c;
+use {defmt_rtt as _, panic_probe as _};
 
 const ADDR: u16 = 0x0123;
 const MASTER_BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::master::I2cMaster;
@@ -10,7 +8,7 @@ use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const ADDR: u16 = 0x0123;
 const MASTER_BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -10,6 +10,7 @@ use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embedded_hal_async::i2c::I2c;
+use {defmt_rtt as _, panic_probe as _};
 
 const ADDR: u8 = 0x20;
 const MASTER_BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::master::{DutyCycle, I2cMaster};
@@ -10,7 +8,7 @@ use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const ADDR: u8 = 0x20;
 const MASTER_BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_imxrt::{bind_interrupts, i2c, peripherals};
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const NACK_ADDR: u8 = 0x07;
 

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -8,6 +8,7 @@ use embassy_executor::Spawner;
 use embassy_imxrt::{bind_interrupts, i2c, peripherals};
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
+use {defmt_rtt as _, panic_probe as _};
 
 const NACK_ADDR: u8 = 0x07;
 

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::{error, info};
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c;
 use embassy_time::Timer;
 use embedded_hal_1::i2c::I2c;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const ACC_ADDR: u8 = 0x1E;
 

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::{error, info};
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
 const BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -8,6 +8,7 @@ use embassy_executor::Spawner;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
 const BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::Blocking;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
 const BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -7,6 +7,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::Blocking;
+use {defmt_rtt as _, panic_probe as _};
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
 const BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/pwm.rs
+++ b/examples/rt685s-evk/src/bin/pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/pwm.rs
+++ b/examples/rt685s-evk/src/bin/pwm.rs
@@ -1,15 +1,13 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::pac;
 use embassy_imxrt::pwm::{CentiPercent, Channel, MicroSeconds, SCTClockSource, SCTPwm};
 use embassy_imxrt::timer::{CTimerPwm, CTimerPwmPeriodChannel};
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 // TODO: connect with GPIO port when that is ready
 fn setup_gpio() {

--- a/examples/rt685s-evk/src/bin/pwm.rs
+++ b/examples/rt685s-evk/src/bin/pwm.rs
@@ -9,6 +9,7 @@ use embassy_imxrt::pac;
 use embassy_imxrt::pwm::{CentiPercent, Channel, MicroSeconds, SCTClockSource, SCTPwm};
 use embassy_imxrt::timer::{CTimerPwm, CTimerPwmPeriodChannel};
 use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
 
 // TODO: connect with GPIO port when that is ready
 fn setup_gpio() {

--- a/examples/rt685s-evk/src/bin/rng.rs
+++ b/examples/rt685s-evk/src/bin/rng.rs
@@ -3,7 +3,7 @@
 
 use embassy_imxrt_examples as _;
 
-use defmt::*;
+use defmt::{info, unwrap};
 use embassy_executor::Spawner;
 use embassy_imxrt::rng::Rng;
 use embassy_imxrt::{bind_interrupts, peripherals, rng};

--- a/examples/rt685s-evk/src/bin/rng.rs
+++ b/examples/rt685s-evk/src/bin/rng.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{info, unwrap};
 use embassy_executor::Spawner;
 use embassy_imxrt::rng::Rng;
 use embassy_imxrt::{bind_interrupts, peripherals, rng};
 use rand::RngCore;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;

--- a/examples/rt685s-evk/src/bin/rng.rs
+++ b/examples/rt685s-evk/src/bin/rng.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::*;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -5,7 +5,7 @@ use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt::rtc::*;
+use embassy_imxrt::rtc::{Datetime, RtcDatetime};
 use embassy_time::Timer;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::rtc::{Datetime, RtcDatetime};
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/sha256-async.rs
+++ b/examples/rt685s-evk/src/bin/sha256-async.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{info, trace};
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{hasher, Hashcrypt};
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/sha256-async.rs
+++ b/examples/rt685s-evk/src/bin/sha256-async.rs
@@ -3,7 +3,7 @@
 
 use embassy_imxrt_examples as _;
 
-use defmt::*;
+use defmt::{info, trace};
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{hasher, Hashcrypt};
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/rt685s-evk/src/bin/sha256-async.rs
+++ b/examples/rt685s-evk/src/bin/sha256-async.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use embassy_imxrt_examples as _;
+
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{hasher, Hashcrypt};

--- a/examples/rt685s-evk/src/bin/sha256.rs
+++ b/examples/rt685s-evk/src/bin/sha256.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::{info, trace};
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{hasher, Hashcrypt};
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/sha256.rs
+++ b/examples/rt685s-evk/src/bin/sha256.rs
@@ -3,7 +3,7 @@
 
 use embassy_imxrt_examples as _;
 
-use defmt::*;
+use defmt::{info, trace};
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{hasher, Hashcrypt};
 use {defmt_rtt as _, panic_probe as _};

--- a/examples/rt685s-evk/src/bin/sha256.rs
+++ b/examples/rt685s-evk/src/bin/sha256.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use embassy_imxrt_examples as _;
+
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{hasher, Hashcrypt};

--- a/examples/rt685s-evk/src/bin/time-driver-blinky.rs
+++ b/examples/rt685s-evk/src/bin/time-driver-blinky.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/time-driver-blinky.rs
+++ b/examples/rt685s-evk/src/bin/time-driver-blinky.rs
@@ -1,13 +1,11 @@
 #![no_main]
 #![no_std]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {

--- a/examples/rt685s-evk/src/bin/timer.rs
+++ b/examples/rt685s-evk/src/bin/timer.rs
@@ -1,15 +1,13 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::clocks::ClockConfig;
 use embassy_imxrt::timer::{CaptureChEdge, CaptureTimer, CountingTimer};
 use embassy_imxrt::{bind_interrupts, peripherals, timer};
 use embassy_time::Timer as Tmr;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     CTIMER0 => timer::CtimerInterruptHandler<peripherals::CTIMER0_COUNT_CHANNEL0>;

--- a/examples/rt685s-evk/src/bin/timer.rs
+++ b/examples/rt685s-evk/src/bin/timer.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+use embassy_imxrt_examples as _;
+
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::clocks::ClockConfig;

--- a/examples/rt685s-evk/src/bin/uart-async.rs
+++ b/examples/rt685s-evk/src/bin/uart-async.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/uart-async.rs
+++ b/examples/rt685s-evk/src/bin/uart-async.rs
@@ -1,14 +1,12 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Async, Uart};
 use embassy_imxrt::{bind_interrupts, peripherals, uart};
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     FLEXCOMM2 => uart::InterruptHandler<peripherals::FLEXCOMM2>;

--- a/examples/rt685s-evk/src/bin/uart.rs
+++ b/examples/rt685s-evk/src/bin/uart.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use defmt::info;
 use embassy_executor::Spawner;

--- a/examples/rt685s-evk/src/bin/uart.rs
+++ b/examples/rt685s-evk/src/bin/uart.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Blocking, Uart, UartRx, UartTx};
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::task]
 async fn usart4_task(mut uart: UartRx<'static, Blocking>) {

--- a/examples/rt685s-evk/src/bin/wwdt.rs
+++ b/examples/rt685s-evk/src/bin/wwdt.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate embassy_imxrt_examples;
+use embassy_imxrt_examples as _;
 
 use cortex_m::peripheral::NVIC;
 use defmt::{info, warn};

--- a/examples/rt685s-evk/src/bin/wwdt.rs
+++ b/examples/rt685s-evk/src/bin/wwdt.rs
@@ -1,15 +1,13 @@
 #![no_std]
 #![no_main]
 
-use embassy_imxrt_examples as _;
-
 use cortex_m::peripheral::NVIC;
 use defmt::{info, warn};
 use embassy_executor::Spawner;
 use embassy_imxrt::pac::{interrupt, Interrupt};
 use embassy_imxrt::wwdt::WindowedWatchdog;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _};
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/lib.rs
+++ b/examples/rt685s-evk/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 use mimxrt600_fcb::FlexSPIFlashConfigurationBlock;
-use {defmt_rtt as _, panic_probe as _};
 
 // auto-generated version information from Cargo.toml
 include!(concat!(env!("OUT_DIR"), "/biv.rs"));


### PR DESCRIPTION
Hey,

This PR makes a few adjustments to the examples in an attempt to improve their teaching value. The examples will probably be an important tool for new users, so I think it is good to try and polish them a little more. They're already quite useful, but I did notice a few things that could be improved :)

The PR:
1) Replaces `extern crate embassy_imxrt_examples` with `use embassy_imxrt_examples as _`. This is the standard way it is done for external crates that need to be linked in, like `defmt_rtt` and `panic_probe`.
2) Replaces star imports with specific imports. This makes it more explicit what is actually imported, which helps to read the code. In general, star imports are usually frowned upon (with the exception of `pub use self::submodule::*`).
3) Simplifies the DMA example by removing the custom macro.
4) Fixes the trait sealing in the storage service example (it did not actually seal the trait).
5) Moves the `defmt_rtt` and `panic_probe` imports out of the library and into specific examples. If users use the examples as a starting point it would be best if the example is pretty much complete without hiding details in a custom library.

    Arguably, this also means that the `BIV`, `OTFAD`, `FCB` and `KEYSTORE` should be moved to the specific examples. But that's a bit more duplication than I wanted to do in this PR without discussion first.

They're all separate commits, so it's relatively straightforward to remove any of them if you do not agree with (all) the changes.