### PR TITLE
Add simple keyboard example

### DIFF
--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +73,7 @@ checksum = "331afbb18ce7b644c0b428726d369c5dd37ca0b815d72a459fcc2896c3c8ad32"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -78,7 +84,7 @@ checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -159,7 +165,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -195,7 +201,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -206,7 +212,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -238,7 +244,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -312,7 +318,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -383,6 +389,7 @@ dependencies = [
  "embedded-storage",
  "embedded-storage-async",
  "futures",
+ "keyberon",
  "mimxrt600-fcb",
  "panic-probe",
  "rand",
@@ -638,7 +645,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -732,6 +739,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "keyberon"
+version = "0.2.0"
+source = "git+https://github.com/TeXitoi/keyberon#32a7eed1bec438792ec21a4c16631724d5f5d244"
+dependencies = [
+ "arraydeque",
+ "either",
+ "embedded-hal 1.0.0",
+ "heapless 0.8.0",
+ "keyberon-macros",
+ "usb-device",
+]
+
+[[package]]
+name = "keyberon-macros"
+version = "0.1.0"
+source = "git+https://github.com/TeXitoi/keyberon#32a7eed1bec438792ec21a4c16631724d5f5d244"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -838,6 +868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +882,30 @@ dependencies = [
  "cobs",
  "heapless 0.7.17",
  "serde",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -867,7 +927,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -971,7 +1031,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1008,6 +1068,16 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -1040,7 +1110,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1056,10 +1126,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "usb-device"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -49,3 +49,4 @@ embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
 mimxrt600-fcb = "0.2.2"
 rand = { version = "0.8.5", default-features = false }
+keyberon = { git = "https://github.com/TeXitoi/keyberon" }

--- a/examples/rt685s-evk/src/bin/keyboard.rs
+++ b/examples/rt685s-evk/src/bin/keyboard.rs
@@ -1,0 +1,116 @@
+#![no_std]
+#![no_main]
+
+extern crate embassy_imxrt_examples;
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_imxrt::clocks::delay_loop_clocks;
+use embassy_imxrt::gpio;
+use embassy_imxrt::gpio::{Input, Level, Output};
+use embassy_imxrt::iopctl::{DriveMode, DriveStrength, Inverter, Pull, SlewRate};
+use embassy_time::{Duration, Timer};
+use keyberon::debounce::Debouncer;
+use keyberon::key_code::KbHidReport;
+use keyberon::layout::Layout;
+use keyberon::matrix::Matrix;
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+
+const COLS: usize = 4;
+const ROWS: usize = 4;
+const N_LAYERS: usize = 1;
+
+type Keymap = keyberon::layout::Layers<COLS, ROWS, N_LAYERS>;
+
+static KEYMAP: Keymap = keyberon::layout::layout! {
+  {
+    [ Kp7 Kp8   Kp9     KpSlash ],
+    [ Kp4 Kp5   Kp6     KpAsterisk ],
+    [ Kp1 Kp2   Kp3     KpMinus ],
+    [ Kp0 KpDot KpEqual KpPlus ],
+ }
+};
+
+#[embassy_executor::task]
+async fn led_task(mut led: gpio::Output<'static>) {
+    loop {
+        led.toggle();
+        Timer::after_secs(1).await;
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_imxrt::init(Default::default());
+
+    info!("Keyboard example using Keyberon");
+
+    spawner
+        .spawn(led_task(gpio::Output::new(
+            p.PIO0_26,
+            gpio::Level::Low,
+            gpio::DriveMode::PushPull,
+            gpio::DriveStrength::Normal,
+            gpio::SlewRate::Standard,
+        )))
+        .unwrap();
+
+    let rows = [
+        Input::new(p.PIO1_6, Pull::Up, Inverter::Disabled),
+        Input::new(p.PIO1_4, Pull::Up, Inverter::Disabled),
+        Input::new(p.PIO1_3, Pull::Up, Inverter::Disabled),
+        Input::new(p.PIO0_18, Pull::Up, Inverter::Disabled),
+    ];
+
+    let cols = [
+        Output::new(
+            p.PIO0_30,
+            Level::Low,
+            DriveMode::PushPull,
+            DriveStrength::Normal,
+            SlewRate::Standard,
+        ),
+        Output::new(
+            p.PIO0_29,
+            Level::Low,
+            DriveMode::PushPull,
+            DriveStrength::Normal,
+            SlewRate::Standard,
+        ),
+        Output::new(
+            p.PIO0_28,
+            Level::Low,
+            DriveMode::PushPull,
+            DriveStrength::Normal,
+            SlewRate::Standard,
+        ),
+        Output::new(
+            p.PIO0_27,
+            Level::Low,
+            DriveMode::PushPull,
+            DriveStrength::Normal,
+            SlewRate::Standard,
+        ),
+    ];
+
+    let mut matrix = Matrix::new(rows, cols).unwrap();
+    let mut debouncer = Debouncer::new([[false; 4]; 4], [[false; 4]; 4], 5);
+    let mut layout = Layout::new(&KEYMAP);
+
+    loop {
+        for event in debouncer.events(matrix.get_with_delay(|| delay_loop_clocks(5, 250_000_000)).unwrap()) {
+            layout.event(event);
+        }
+
+        layout.tick();
+
+        let report = KbHidReport::from_iter(layout.keycodes());
+        let bytes = report.as_bytes();
+
+        if !bytes.iter().all(|k| *k == 0x00) {
+            info!("HID Report Bytes: {:02x}", report.as_bytes());
+        }
+
+        Timer::after(Duration::from_millis(5)).await;
+    }
+}


### PR DESCRIPTION
Simple example using my minimal 4x4 keymatrix. Note that `keyberon` sort of expects a `usb_device` to be available such that it can send HID reports. Because we don't have that (yet?), for now I'm just dumping the data through `defmt-rtt` and, to reduce console spamming, only when the report is not empty.