### PR TITLE
RTC driver / time driver: fix soundness bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ defmt = [
 ## Enable features requiring `embassy-time`
 time = ["dep:embassy-time", "embassy-embedded-hal/time"]
 
-## Enable usage of the RTC driver.  This is mutually exclusive with the time-driver-rtc time driver; if you want the RTC driver, use time-driver-os-timer instead.
-rtc = []
-
 ## Enable custom embassy time-driver implementation, using 32KHz RTC
 time-driver-rtc = ["_time-driver", "embassy-time-driver?/tick-hz-1_000"]
 
@@ -49,7 +46,6 @@ time-driver-rtc = ["_time-driver", "embassy-time-driver?/tick-hz-1_000"]
 time-driver-os-timer = [
     "_time-driver",
     "embassy-time-driver?/tick-hz-1_000_000",
-    "rtc"
 ]
 
 _time-driver = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,17 @@ defmt = [
 ## Enable features requiring `embassy-time`
 time = ["dep:embassy-time", "embassy-embedded-hal/time"]
 
+## Enable usage of the RTC driver.  This is mutually exclusive with the time-driver-rtc time driver; if you want the RTC driver, use time-driver-os-timer instead.
+rtc = []
+
 ## Enable custom embassy time-driver implementation, using 32KHz RTC
 time-driver-rtc = ["_time-driver", "embassy-time-driver?/tick-hz-1_000"]
 
-## Enable custom embassy time-driver implementation, using 32KHz RTC
+## Enable custom embassy time-driver implementation, using 1MHz ostimer clock
 time-driver-os-timer = [
     "_time-driver",
     "embassy-time-driver?/tick-hz-1_000_000",
+    "rtc"
 ]
 
 _time-driver = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod rng;
 // The time driver RTC implementation takes ownership of the RTC, which conflicts with exposing the RTC
 // as a peripheral for end-user use.
 #[cfg(all(feature = "rtc", feature = "time-driver-rtc"))]
-error!("The `rtc` feature is incompatible with the `time-driver-rtc` feature. Please choose one or the other.");
+compile_error!("The `rtc` feature is incompatible with the `time-driver-rtc` feature. Please choose one or the other.");
 
 #[cfg(feature = "rtc")]
 pub mod rtc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,15 @@ pub mod i2c;
 pub mod iopctl;
 pub mod pwm;
 pub mod rng;
+
+// The time driver RTC implementation takes ownership of the RTC, which conflicts with exposing the RTC
+// as a peripheral for end-user use.
+#[cfg(all(feature = "rtc", feature = "time-driver-rtc"))]
+error!("The `rtc` feature is incompatible with the `time-driver-rtc` feature. Please choose one or the other.");
+
+#[cfg(feature = "rtc")]
 pub mod rtc;
+
 /// Time driver for the iMX RT600 series.
 #[cfg(feature = "_time-driver")]
 pub mod time_driver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,7 @@ pub mod iopctl;
 pub mod pwm;
 pub mod rng;
 
-// The time driver RTC implementation takes ownership of the RTC, which conflicts with exposing the RTC
-// as a peripheral for end-user use.
-#[cfg(all(feature = "rtc", feature = "time-driver-rtc"))]
-compile_error!("The `rtc` feature is incompatible with the `time-driver-rtc` feature. Please choose one or the other.");
-
-#[cfg(feature = "rtc")]
+#[cfg(not(feature = "time-driver-rtc"))]
 pub mod rtc;
 
 /// Time driver for the iMX RT600 series.


### PR DESCRIPTION
The RTC driver and RTC time driver both accessed the registers without synchronization.  This led to an issue where writes to the control register could be 'lost'.

This was possible in 'safe' code because the `rtc()` function was not marked `unsafe`, despite being unable to enforce the invariant that the critical section must be held while writing to the control register.

This change addresses the problem with a few fixes:
- Makes the RTC driver and RTC time driver mutually exclusive to avoid the muddled ownership semantics for the RTC hardware
- Makes the `rtc()` functions `unsafe` to reflect that they cannot uphold the synchronization requirement on the ctrl register.
- Fixes a bug in the RTC time driver that caused it to panic due to an underflow if a prior firmware on the device wrote a large number to general-purpose register 0.
 
Clients are advised to move to the OS timer-based time driver to retain access to the RTC functionality (i.e. get/set wall-clock datetime).  The OS timer-based driver is the default, so for clients that have not explicitly opted for the RTC timer this will be a transparent change.