### PR TITLE
Implement common traits for RTC functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "fixed",
  "itertools",
  "log",
+ "mcu-traits",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
  "mimxrt685s-pac",
@@ -698,6 +699,13 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mcu-traits"
+version = "0.1.0"
+dependencies = [
+ "defmt 1.0.1",
+]
 
 [[package]]
 name = "mimxrt600-fcb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,9 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = [
 embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
+
+# TODO source mcu-traits from github, not local filesystem before checking in PR
+mcu-traits = { path = "../embedded-mcu/mcu-traits" }
 mimxrt600-fcb = "0.2.0"
 document-features = "0.2.7"
 paste = "1.0"

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "embedded-io-async",
  "fixed",
  "itertools",
+ "mcu-traits",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
  "mimxrt685s-pac",
@@ -724,6 +725,13 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "mcu-traits"
+version = "0.1.0"
+dependencies = [
+ "defmt 1.0.1",
 ]
 
 [[package]]

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "embedded-io-async",
  "fixed",
  "itertools",
+ "mcu-traits",
  "mimxrt600-fcb",
  "mimxrt633s-pac",
  "mimxrt685s-pac",
@@ -390,6 +391,7 @@ dependencies = [
  "embedded-storage-async",
  "futures",
  "keyberon",
+ "mcu-traits",
  "mimxrt600-fcb",
  "panic-probe",
  "rand",
@@ -778,6 +780,13 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "mcu-traits"
+version = "0.1.0"
+dependencies = [
+ "defmt 1.0.1",
 ]
 
 [[package]]

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -48,5 +48,8 @@ futures = { version = "0.3.30", default-features = false, features = [
 embedded-storage = { version = "0.3" }
 embedded-storage-async = { version = "0.4.1" }
 mimxrt600-fcb = "0.2.2"
+
+# TODO source mcu-traits from github, not local filesystem before checking in PR
+mcu-traits = { path = "../../../embedded-mcu/mcu-traits" }
 rand = { version = "0.8.5", default-features = false }
 keyberon = { git = "https://github.com/TeXitoi/keyberon" }

--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -3,34 +3,55 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use embassy_imxrt::rtc::{Datetime, RtcDatetime};
+use embassy_imxrt::rtc::Rtc;
 use embassy_time::Timer;
+use mcu_traits::datetime::{Datetime, UncheckedDatetime};
+use mcu_traits::{DatetimeClock, Nvram, NvramStorage};
+
 use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_imxrt::init(Default::default());
-    let r = RtcDatetime::new(p.RTC);
 
-    let datetime = Datetime {
+    let mut r = Rtc::new(p.RTC);
+
+    let (dt_clock, rtc_nvram) = r.split();
+
+    // Datetime clock example
+    let datetime = Datetime::new(UncheckedDatetime {
         year: 2024,
         month: 10,
         day: 4,
         hour: 16,
-        minute: 0,
-        second: 0,
-    };
-    let ret = r.set_datetime(&datetime);
+        ..Default::default()
+    })
+    .unwrap();
+
+    let ret = dt_clock.set_current_datetime(&datetime);
     info!("RTC set time: {:?}", datetime);
     // check if the set is valid
     assert!(ret.is_ok());
 
-    info!("Wait for 20 seconds");
-    //wait for 20 seconds
-    Timer::after_millis(20000).await;
+    info!("Wait for 5 seconds");
+    //wait for 5 seconds
+    Timer::after_millis(5000).await;
 
     // get the datetime set and compare
-    let result = r.get_datetime();
+    let result = dt_clock.get_current_datetime();
     assert!(result.is_ok());
     info!("RTC get time: {:?}", result.unwrap());
+
+    // NVRAM example
+
+    // Note that unused registers are handled with a '..' pattern, rather than explictly naming all registers.
+    // This approach is recommended, because it allows the code to remain compatible with optional HAL features that
+    // may consume some of these registers, so long as the total number of registers is not overcommitted.
+    // If the number of registers is overcommitted, the code will not compile, which will help catch the issue early.
+    let [gp0, gp1, ..] = rtc_nvram.storage();
+    info!("RTC NVRAM GP0: {:?}", gp0.read());
+    info!("RTC NVRAM GP1: {:?}", gp1.read());
+
+    gp0.write(12345678);
+    info!("RTC NVRAM GP0: {:?}", gp0.read());
 }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,289 +1,177 @@
 //! RTC DateTime driver.
 
-use crate::{pac, peripherals, Peri};
+use core::marker::PhantomData;
 
-// SAFETY: This function allows access to the RTC peripheral's register block without ownership checks.
-//         If a register is to be accessed from multiple locations (e.g. an interrupt), access to it
-//         must be synchronized using a critical section or other synchronization mechanism.
+use crate::{pac, peripherals, Peri};
+use mcu_traits::datetime::Datetime;
+use mcu_traits::{DatetimeClock, DatetimeClockError, Nvram, NvramStorage};
+
+/// Number of general-purpose registers in the RTC NVRAM
+// If you need to consume some of these registers for internal HAL use, write a feature flag that reduces this count,
+// and use registers starting from the end of the array (i.e. use gpreg7 first) so we don't need to renumber based on
+// which feature flags are enabled.
+const IMXRT_GPREG_COUNT: usize = 8;
+
+/// Returns a reference to the RTC peripheral's register block.
+/// SAFETY: The caller is responsible for ensuring that no individual register is touched by multiple threads/interrupts at the same time.
 unsafe fn rtc() -> &'static pac::rtc::RegisterBlock {
     unsafe { &*pac::Rtc::ptr() }
 }
 
-/// Represents a date and time.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(PartialEq, Debug)]
-pub struct Datetime {
-    /// The year component of the date.
-    pub year: u16,
-    /// The month component of the date (1-12).
-    pub month: u8,
-    /// The day component of the date (1-31).
-    pub day: u8,
-    /// The hour component of the time (0-23).
-    pub hour: u8,
-    /// The minute component of the time (0-59).
-    pub minute: u8,
-    /// The second component of the time (0-59).
-    pub second: u8,
+/// Represents the real-time clock (RTC) peripheral and provides access to its datetime clock and NVRAM functionality.
+pub struct Rtc<'r> {
+    _p: Peri<'r, peripherals::RTC>,
+    clock: RtcDatetimeClock<'r>,
+    nvram: RtcNvram<'r>,
 }
 
-/// Default implementation for `Datetime`.
-impl Default for Datetime {
-    fn default() -> Self {
-        Datetime {
-            year: 1970,
-            month: 1,
-            day: 1,
-            hour: 0,
-            minute: 0,
-            second: 0,
+impl<'r> Rtc<'r> {
+    /// Create a new `Rtc` instance, taking ownership of the RTC peripheral.
+    pub fn new(rtc: Peri<'r, peripherals::RTC>) -> Self {
+        Self {
+            _p: rtc,
+            clock: RtcDatetimeClock { _phantom: PhantomData },
+
+            // SAFETY: Only one instance of Rtc can be created because we consume the Peri<RTC> singleton, which ensures that we only create one instance of RtcNvram.
+            nvram: unsafe { RtcNvram::new() },
         }
+    }
+
+    /// Obtains a clock and NVRAM wrapper from the Rtc peripheral.
+    pub fn split(&'r mut self) -> (&'r mut RtcDatetimeClock<'r>, &'r mut RtcNvram<'r>) {
+        (&mut self.clock, &mut self.nvram)
     }
 }
 
-/// Represents a real-time clock datetime.
-pub struct RtcDatetime<'r> {
-    _p: Peri<'r, peripherals::RTC>,
-}
-
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(PartialEq, Debug)]
-/// Represents the result of a datetime validation.
-pub enum Error {
-    /// The year is invalid.
-    InvalidYear,
-    /// The month is invalid.
-    InvalidMonth,
-    /// The day is invalid.
-    InvalidDay,
-    /// The hour is invalid.
-    InvalidHour,
-    /// The minute is invalid.
-    InvalidMinute,
-    /// The second is invalid.
-    InvalidSecond,
-    /// RTC is not enabled.
-    RTCNotEnabled,
+/// Implementation of the `DatetimeClock` trait - allows setting and getting the current date and time in structured format.
+pub struct RtcDatetimeClock<'r> {
+    _phantom: PhantomData<&'r Peri<'r, peripherals::RTC>>,
 }
 
 /// Implementation for `RtcDatetime`.
-impl<'r> RtcDatetime<'r> {
-    /// Create a new `RtcDatetime` instance.
-    pub fn new(rtc: Peri<'r, peripherals::RTC>) -> Self {
-        Self { _p: rtc }
-    }
-    /// check valid datetime.
-    pub fn is_valid_datetime(&self, time: &Datetime) -> Result<(), Error> {
-        // Validate year
-        if time.year < 1970 {
-            return Err(Error::InvalidYear);
-        }
-
-        // Validate month
-        if time.month < 1 || time.month > 12 {
-            return Err(Error::InvalidMonth);
-        }
-
-        // Validate day
-        if time.day < 1 {
-            return Err(Error::InvalidDay);
-        }
-
-        match time.month {
-            1 | 3 | 5 | 7 | 8 | 10 | 12 => {
-                if time.day > 31 {
-                    return Err(Error::InvalidDay);
-                }
-            }
-            4 | 6 | 9 | 11 => {
-                if time.day > 30 {
-                    return Err(Error::InvalidDay);
-                }
-            }
-            2 => {
-                if self.is_leap_year(time.year) {
-                    if time.day > 29 {
-                        return Err(Error::InvalidDay);
-                    }
-                } else if time.day > 28 {
-                    return Err(Error::InvalidDay);
-                }
-            }
-            _ => return Err(Error::InvalidDay),
-        }
-
-        // Validate hour
-        if time.hour > 23 {
-            return Err(Error::InvalidHour);
-        }
-
-        // Validate minute
-        if time.minute > 59 {
-            return Err(Error::InvalidMinute);
-        }
-
-        // Validate second
-        if time.second > 59 {
-            return Err(Error::InvalidSecond);
-        }
-        Ok(())
-    }
-
-    /// Check if a year is a leap year.
-    fn is_leap_year(&self, year: u16) -> bool {
-        (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
-    }
-
-    /// Convert a datetime to seconds since 1970-01-01 00:00:00.
-    pub fn convert_datetime_to_secs(&self, datetime: &Datetime) -> u32 {
-        let mut days: u32 = 0;
-
-        // Calculate days from full years from 1970 to the current year
-        for year in 1970..datetime.year {
-            days += 365;
-            if self.is_leap_year(year) {
-                days += 1;
-            }
-        }
-
-        // Calculate days from January to the current month
-        const DAYS_IN_MONTH: [u32; 12] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30];
-        for month in 1..datetime.month {
-            days += DAYS_IN_MONTH[month as usize];
-            if month == 2 && self.is_leap_year(datetime.year) {
-                days += 1;
-            }
-        }
-
-        // Calculate days from the first day of the month to the current day
-        days += datetime.day as u32 - 1;
-
-        // Calculate seconds from the first day of the month to the current day
-        let secs = datetime.second as u32 + datetime.minute as u32 * 60 + datetime.hour as u32 * 3600;
-
-        days * 86400 + secs
-    }
-
-    /// Convert seconds since 1970-01-01 00:00:00 to a datetime.
-    fn convert_secs_to_datetime(&self, secs: u32) -> Datetime {
-        let mut days = secs / 86400;
-        let mut secs = secs % 86400;
-
-        let mut year = 1970;
-        let mut month = 1;
-        let mut day = 1;
-
-        // Calculate year
-        while days >= 365 {
-            if self.is_leap_year(year) {
-                if days >= 366 {
-                    days -= 366;
-                } else {
-                    break;
-                }
-            } else {
-                days -= 365;
-            }
-            year += 1;
-        }
-
-        // Calculate month
-        let days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30];
-        while days >= days_in_month[month as usize] {
-            if month == 2 && self.is_leap_year(year) {
-                if days >= 29 {
-                    days -= 29;
-                } else {
-                    break;
-                }
-            } else {
-                days -= days_in_month[month as usize];
-            }
-            month += 1;
-        }
-
-        // Calculate day
-        day += days;
-
-        // Calculate hour, minute, and second
-        let hour = secs / 3600;
-        secs %= 3600;
-        let minute = secs / 60;
-        let second = secs % 60;
-
-        Datetime {
-            year,
-            month,
-            day: day as u8,
-            hour: hour as u8,
-            minute: minute as u8,
-            second: second as u8,
-        }
-    }
-
-    /// Set the datetime.
-    pub fn set_datetime(&self, datetime: &Datetime) -> Result<(), Error> {
-        // SAFETY: Clear RTC_EN bit before setting time to handle race condition
-        //         when the count is in middle of a transition
-        //         There is 21 mS inacurracy in the time set
-        //         Todo: https://github.com/OpenDevicePartnership/embassy-imxrt/issues/121
-        self.is_valid_datetime(datetime)?;
-        let secs = self.convert_datetime_to_secs(datetime);
-        self.set_datetime_in_secs(secs);
-        Ok(())
-    }
-
-    ///Set the datetime in seconds
-    pub fn set_datetime_in_secs(&self, secs: u32) {
-        // SAFETY: This is safe because calling this function requires an instance of an RtcDatetime,
-        //         which takes ownership of the RTC peripheral, and we don't access any RTC registers from an interrupt.
+impl<'r> RtcDatetimeClock<'r> {
+    ///Set the datetime in seconds since the Unix time epoch (January 1, 1970).
+    fn set_datetime_in_secs(&self, secs: u64) {
+        // SAFETY: We have sole ownership of the RTC peripheral and we enforce that there is only one instance of RtcDatetime,
+        //         so we can safely access it as long as it's always from an object that has the handle-to-RTC.
         let r = unsafe { rtc() };
+
+        let secs: u32 = secs.try_into().unwrap(); // This overflows in 2106, but we should be out of service by then.
         r.ctrl().modify(|_r, w| w.rtc_en().disable());
         r.count().write(|w| unsafe { w.bits(secs) });
         r.ctrl().modify(|_r, w| w.rtc_en().enable());
     }
 
-    /// Get the datetime.
-    pub fn get_datetime(&self) -> Result<Datetime, Error> {
-        let datetime;
-        let res;
-        match self.get_datetime_as_secs() {
-            Ok(secs) => {
-                datetime = self.convert_secs_to_datetime(secs);
-                match self.is_valid_datetime(&datetime) {
-                    Ok(()) => {
-                        res = Ok(datetime);
-                    }
-                    Err(e) => {
-                        res = Err(e);
-                    }
-                }
-            }
-            Err(e) => {
-                res = Err(e);
-            }
-        }
-        res
-    }
-
-    /// Get the datetime as UTC seconds
-    pub fn get_datetime_as_secs(&self) -> Result<u32, Error> {
-        // SAFETY: This is safe because calling this function requires an instance of an RtcDatetime,
-        //         which takes ownership of the RTC peripheral, and we don't access any RTC registers from an interrupt.
+    /// Get the datetime as seconds since the Unix time epoch (January 1, 1970).
+    fn get_datetime_in_secs(&self) -> Result<u64, DatetimeClockError> {
+        // SAFETY: We have sole ownership of the RTC peripheral and we enforce that there is only one instance of RtcDatetime,
+        //         so we can safely access it as long as it's always from an object that has the handle-to-RTC.
         let r = unsafe { rtc() };
-        let secs;
-        //  If RTC is not enabled return error
+
         if r.ctrl().read().rtc_en().bit_is_clear() {
-            return Err(Error::RTCNotEnabled);
+            return Err(DatetimeClockError::NotEnabled);
         }
-        loop {
+
+        // Wait for the count to stabilize - it can change in the middle of a read, so we need to read it twice and make sure they match.
+        let secs = loop {
             let secs1 = r.count().read().bits();
             let secs2 = r.count().read().bits();
             if secs1 == secs2 {
-                secs = secs1;
-                break;
+                break secs1;
             }
+        };
+
+        Ok(secs.try_into().unwrap()) // This overflows in 2106, but we should be out of service by then.
+    }
+}
+
+impl DatetimeClock for RtcDatetimeClock<'_> {
+    /// Returns the current structured date and time.
+    fn get_current_datetime(&self) -> Result<Datetime, DatetimeClockError> {
+        Ok(Datetime::from_unix_time_seconds(self.get_datetime_in_secs()?))
+    }
+
+    /// Sets the current structured date and time.
+    fn set_current_datetime(&mut self, datetime: &Datetime) -> Result<(), DatetimeClockError> {
+        // SAFETY: Clear RTC_EN bit before setting time to handle race condition
+        //         when the count is in middle of a transition
+        //         There is 21 mS inacurracy in the time set
+        //         Todo: https://github.com/OpenDevicePartnership/embassy-imxrt/issues/121
+        _ = self.set_datetime_in_secs(datetime.to_unix_time_seconds());
+        Ok(())
+    }
+
+    // TODO As currently implemented, we only return times with 1s resolution.  However, the hardware is capable of 1KHz
+    //      resolution in some configurations.  In the future, we may consider adding a feature flag to enable setting
+    //      timestamps with 1KHz resolution, but we don't currently have a use case for that.
+    //
+    const MAX_RESOLUTION_HZ: u32 = 1;
+}
+
+/// Represents a storage cell in the RTC's general-purpose NVRAM registers.
+pub struct RtcNvramStorage<'r> {
+    /// Which general-purpose register index this storage cell represents.
+    gpreg_idx: usize,
+    _phantom: PhantomData<&'r Peri<'r, peripherals::RTC>>,
+}
+
+impl<'r> NvramStorage<'r, u32> for RtcNvramStorage<'r> {
+    /// Reads the value from the NVRAM storage cell.
+    fn read(&self) -> u32 {
+        // SAFETY: If only a single instance of NvramStorage exists for a given gpreg, we can safely access it.
+        //         The function that constructs us is responsible for enforcing that only a single instance exists.
+        unsafe { rtc() }.gpreg(self.gpreg_idx).read().gpdata().bits()
+    }
+
+    /// Writes a value to the NVRAM storage cell.
+    fn write(&mut self, value: u32) {
+        // SAFETY: If only a single instance of NvramStorage exists for a given gpreg, we can safely access it.
+        //         The function that constructs us is responsible for enforcing that only a single instance exists.
+        //         General-purpose registers have no side effects and are not shared between multiple logical fields, so bits() is safe.
+        unsafe { rtc() }
+            .gpreg(self.gpreg_idx)
+            .write(|w| unsafe { w.gpdata().bits(value) });
+    }
+}
+
+impl<'r> RtcNvramStorage<'r> {
+    /// Creates a new `RtcNvramStorage` instance for the specified register index.
+    /// SAFETY: The caller is responsible for ensuring that only one RtcNvramStorage instance is created for each register index.
+    unsafe fn new(gpreg_idx: usize) -> Self {
+        Self {
+            gpreg_idx: match gpreg_idx {
+                0..IMXRT_GPREG_COUNT => gpreg_idx,
+                _ => panic!("Invalid GPREG index: {}", gpreg_idx),
+            },
+            _phantom: PhantomData,
         }
-        Ok(secs)
+    }
+}
+
+/// Represents the RTC's NVRAM storage, which consists of 8 general-purpose registers (GPREGs).
+pub struct RtcNvram<'r> {
+    storage: [RtcNvramStorage<'r>; IMXRT_GPREG_COUNT],
+}
+
+impl<'r> RtcNvram<'r> {
+    /// Creates a representation of the RTC's NVRAM storage.
+    /// SAFETY: It is only safe to construct an RtcNvram once, because it contains a static reference to the RTC peripheral.
+    unsafe fn new() -> Self {
+        Self {
+            storage: core::array::from_fn(|gpreg_idx| {
+                // SAFETY: We ensure that we only create one instance per index. Our caller is responsible
+                //         for only calling this once, and this function is marked unsafe to signal that
+                //         they must enforce that.
+                unsafe { RtcNvramStorage::new(gpreg_idx) }
+            }),
+        }
+    }
+}
+
+impl<'r> Nvram<'r, RtcNvramStorage<'r>, u32, IMXRT_GPREG_COUNT> for RtcNvram<'r> {
+    fn storage(&'r mut self) -> &'r mut [RtcNvramStorage<'r>; IMXRT_GPREG_COUNT] {
+        // SAFETY: We have sole ownership of the RTC peripheral and we enforce that there is only one instance of RtcDatetime,
+        //         so we can safely access it as long as it's always from an object that has the handle-to-RTC.
+        &mut self.storage
     }
 }


### PR DESCRIPTION
This change implements the common RTC traits introduced in https://github.com/OpenDevicePartnership/embedded-mcu/pull/4.  As part of this implementation, the datetime type is migrated to embedded-mcu to support the DatetimeClock trait.