### PR TITLE
rng: add recovery from error and disable HW test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,9 +682,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_cell"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89b0684884a883431282db1e4343f34afc2ff6996fe1f4a1664519b66e14c1e"
+checksum = "0530892bb4fa575ee0da4b86f86c667132a94b74bb72160f58ee5a4afec74c23"
 dependencies = [
  "portable-atomic",
 ]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -12,3 +12,8 @@ who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-deploy"
 version = "0.4.1"
 notes = "New version of mimxrt633s-pac merely introduces safe enum variants for IRULESTAT register. No new unsafe blocks are introduced."
+
+[[audits.static_cell]]
+who = "jerrysxie <jerryxie@microsoft.com>"
+criteria = "safe-to-run"
+delta = "2.1.0 -> 2.1.1"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -43,12 +43,6 @@ audit-as-crates-io = false
 [policy.embassy-time-queue-utils]
 audit-as-crates-io = false
 
-[policy.embedded-batteries]
-audit-as-crates-io = false
-
-[policy.embedded-batteries-async]
-audit-as-crates-io = false
-
 [[exemptions.atomic-polyfill]]
 version = "1.0.3"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
RNG is failing with frequency check when main clock is running at a high clock rate (beyond 16 MHz). NXP acknowledged there is an issue with the HW entropy test at higher clock rates and recommended to disable HW entropy test + implement SW entropy test.

NXP HW test disabling code snippet:
```c
void disable_HW_test(void)
{
    /* Turn off TRNG self test */
    TRNG0->MCTL |= TRNG_MCTL_PRGM(1); //Enable MCTL[PRGM] to change to Programming mode
    TRNG0->MCTL |= TRNG_MCTL_TRNG_ACC(1); //Enable MCTL[TRNG_ACC] access mode
    TRNG0->FRQMIN = 0x00000000;
    TRNG0->FRQMAX = 0xFFFFFFFF;
    TRNG0->PKRMAX = 0x0000FFFE;
    TRNG0->PKRRNG = 0x0000FFFF;
    TRNG0->SCML   = 0xFFFFFFFE;
    TRNG0->SCR1L  = 0x7FFF7FFE;
    TRNG0->SCR2L  = 0x3FFF3FFE;
    TRNG0->SCR3L  = 0x1FFF1FFE;
    TRNG0->SCR4L  = 0x0FFF0FFE;
    TRNG0->SCR5L  = 0x07FF07FE;
    TRNG0->SCR6PL = 0x07FF07FE;
    TRNG0->SCMISC = 0x000000FF;
    TRNG0->MCTL &= ~(TRNG_MCTL_PRGM_MASK); //Disable MCTL[PRGM] to change to Run mode
}
```

This change disables the HW test. We are still working on the SW entropy test with NXP.

Related issues: #454 #142
