### PR TITLE
Feed watchdog immediately after unleashing it

### DIFF
--- a/src/wwdt.rs
+++ b/src/wwdt.rs
@@ -197,6 +197,9 @@ impl<'d> WindowedWatchdog<'d> {
     /// must be performed before this call.
     pub fn unleash(&mut self) {
         self.info.regs.mod_().modify(|_, w| w.wden().set_bit());
+
+        // A feed must be performed after setting WDEN bit to actually enable watchdog
+        self.feed();
     }
 
     /// Reloads the watchdog timeout counter to the time set by [`Self::set_timeout`].


### PR DESCRIPTION
Watchdog must be fed after enabling, so call `feed()` within `unleash()`. This was done originally but a commit accidentally removed this functionality while making other changes, so reintroduce that line.

 Resolves #460 