### PR TITLE
i2c examples: remove traces before initialization

### DIFF
--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -132,8 +132,9 @@ async fn master_service(mut master: I2cMaster<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2c loopback example");
     let p = embassy_imxrt::init(Default::default());
+
+    info!("i2c loopback example");
 
     let slave = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -102,8 +102,9 @@ async fn master_service(mut master: I2cMaster<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2c loopback example");
     let p = embassy_imxrt::init(Default::default());
+
+    info!("i2c loopback example");
 
     let slave = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -41,7 +41,6 @@ async fn main(_spawner: Spawner) {
 
     // Acc is connected to P0_18_FC2_SCL and P0_17_FC2_SDA for I2C
     // Acc RESET gpio is P1_7_RST
-    info!("i2c example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     info!("i2c example - Configure GPIOs");

--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -58,7 +58,6 @@ async fn slave_service(mut i2c: I2cSlave<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2cs example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -53,7 +53,6 @@ async fn slave_service(i2c: I2cSlave<'static, Blocking>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2cs example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5


### PR DESCRIPTION
Tracing before timer is initialized is bad new because defmt needs timestamps, so don't do that.