### PR TITLE
Add i2c-master-drop example

### DIFF
--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -132,8 +132,9 @@ async fn master_service(mut master: I2cMaster<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2c loopback example");
     let p = embassy_imxrt::init(Default::default());
+
+    info!("i2c loopback example");
 
     let slave = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -102,8 +102,9 @@ async fn master_service(mut master: I2cMaster<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2c loopback example");
     let p = embassy_imxrt::init(Default::default());
+
+    info!("i2c loopback example");
 
     let slave = I2cSlave::new_async(p.FLEXCOMM2, p.PIO0_18, p.PIO0_17, Irqs, SLAVE_ADDR.unwrap(), p.DMA0_CH4).unwrap();
 

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -41,7 +41,6 @@ async fn main(_spawner: Spawner) {
 
     // Acc is connected to P0_18_FC2_SCL and P0_17_FC2_SDA for I2C
     // Acc RESET gpio is P1_7_RST
-    info!("i2c example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     info!("i2c example - Configure GPIOs");

--- a/examples/rt685s-evk/src/bin/i2c-master-drop.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-drop.rs
@@ -1,0 +1,91 @@
+#![no_std]
+#![no_main]
+
+use defmt::{error, info};
+use embassy_executor::Spawner;
+use embassy_imxrt::{bind_interrupts, i2c, peripherals};
+use embassy_time::Timer;
+use embedded_hal_async::i2c::I2c;
+use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+
+const ACC_ADDR: u8 = 0x1E;
+const ACC_ID_REG: u8 = 0x0D;
+const ACC_ID: u8 = 0xC7;
+
+bind_interrupts!(struct Irqs {
+    FLEXCOMM2 => i2c::InterruptHandler<peripherals::FLEXCOMM2>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    // Link to data sheet for accelerometer on the RT685S-EVK
+    // https://www.nxp.com/docs/en/data-sheet/FXOS8700CQ.pdf
+    // Max Freq is 400 kHz
+    // Address is 0x1E, 0x1D, 0x1C or 0x1F
+
+    // Link to schematics for RT685S-EVK
+    // https://www.nxp.com/downloads/en/design-support/RT685-DESIGNFILES.zip
+    // File: SPF-35099_E2.pdf
+    // Page 10 shows ACC Sensor at I2C address 0x1E
+
+    // Link to RT6xx User Manual
+    // https://www.nxp.com/webapp/Download?colCode=UM11147
+
+    // Acc is connected to P0_18_FC2_SCL and P0_17_FC2_SDA for I2C
+
+    let mut p = embassy_imxrt::init(Default::default());
+
+    {
+        info!("i2c example - I2cMaster::new");
+        let mut i2c = i2c::master::I2cMaster::new_async(
+            p.FLEXCOMM2.reborrow(),
+            p.PIO0_18.reborrow(),
+            p.PIO0_17.reborrow(),
+            Irqs,
+            Default::default(),
+            p.DMA0_CH5.reborrow(),
+        )
+        .unwrap();
+
+        info!("i2c example - ACC WHO_AM_I register check");
+        let mut reg = [0u8; 1];
+        reg[0] = 0xAA;
+        let result = i2c.write_read(ACC_ADDR, &[ACC_ID_REG], &mut reg).await;
+        if result.is_ok() && reg[0] == ACC_ID {
+            info!("i2c example - Read WHO_AM_I register: {:02X}", reg[0]);
+        } else {
+            error!("i2c example - Error reading WHO_AM_I register {}", result.unwrap_err());
+        }
+    }
+
+    // i2c peripheral is dropped here, so we can re-initialize it to verify that it works after being dropped.
+    info!("i2c example - I2cMaster dropped");
+
+    {
+        info!("i2c example - I2cMaster::new after drop");
+        let mut i2c = i2c::master::I2cMaster::new_async(
+            p.FLEXCOMM2.reborrow(),
+            p.PIO0_18.reborrow(),
+            p.PIO0_17.reborrow(),
+            Irqs,
+            Default::default(),
+            p.DMA0_CH5.reborrow(),
+        )
+        .unwrap();
+
+        info!("i2c example - ACC WHO_AM_I register check");
+        let mut reg = [0u8; 1];
+        reg[0] = 0xAA;
+        let result = i2c.write_read(ACC_ADDR, &[ACC_ID_REG], &mut reg).await;
+        if result.is_ok() && reg[0] == ACC_ID {
+            info!("i2c example - Read WHO_AM_I register: {:02X}", reg[0]);
+        } else {
+            error!("i2c example - Error reading WHO_AM_I register {}", result.unwrap_err());
+        }
+    }
+
+    info!("i2c example - Done!  Busy Loop...");
+    loop {
+        Timer::after_millis(1000).await;
+    }
+}

--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -58,7 +58,6 @@ async fn slave_service(mut i2c: I2cSlave<'static, Async>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2cs example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -53,7 +53,6 @@ async fn slave_service(i2c: I2cSlave<'static, Blocking>) {
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
-    info!("i2cs example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     // NOTE: Tested with a raspberry pi 5 as master controller connected FC2 to i2c on Pi5


### PR DESCRIPTION
Add an example showing how to pass pins into an I2C peripheral, then
drop and recreate the I2C peripheral

Based on #462 

