### PR TITLE
Fix flexspi max transfer size per command and command done checking ordering issue

### DIFF
--- a/src/flexspi/nor.rs
+++ b/src/flexspi/nor.rs
@@ -90,8 +90,8 @@ macro_rules! configure_ports_b {
     };
 }
 
-const FIFO_SLOT_SIZE: u32 = 4; // 4 bytes
-const MAX_TRANSFER_SIZE_PER_COMMAND: usize = 65536;
+const FIFO_SLOT_SIZE: u8 = 4; // 4 bytes
+const MAX_TRANSFER_SIZE_PER_COMMAND: u16 = u16::MAX;
 
 /// The default command sequence number to use.
 ///
@@ -1046,7 +1046,7 @@ impl<'d> FlexspiNorStorageBus<'d, Blocking> {
             return Err(NorStorageBusError::StorageBusIoError);
         }
 
-        let num_rx_watermark_slot = self.rx_watermark / FIFO_SLOT_SIZE as u8;
+        let num_rx_watermark_slot = self.rx_watermark / FIFO_SLOT_SIZE;
 
         for watermark_sized_chunk in read_data.chunks_mut(self.rx_watermark as usize) {
             if watermark_sized_chunk.len() < self.rx_watermark as usize {

--- a/src/flexspi/nor.rs
+++ b/src/flexspi/nor.rs
@@ -1,6 +1,5 @@
 //! FlexSPI NOR Storage Bus Driver module for the NXP RT6xx family of microcontrollers
 //!
-use core::cmp::min;
 
 use embassy_hal_internal::{Peri, PeripheralType};
 #[cfg(feature = "time")]


### PR DESCRIPTION
IDATSZ affects read and write in this way:
<img width="619" height="118" alt="image" src="https://github.com/user-attachments/assets/07c873c1-4e73-4913-8ace-670046efd16c" />

IDATSZ is 16-bits:
<img width="890" height="583" alt="image" src="https://github.com/user-attachments/assets/ad182dfa-2584-4bfa-a17d-d333bbd7a317" />

**So max transfer size per command is u16::max.**


**IPCMDDONE should be check after data transfer is done and it needs to be clear so it is not sticky:**
<img width="833" height="374" alt="image" src="https://github.com/user-attachments/assets/d32215a8-3daa-4dc5-8bd6-fa63c31d943a" />




