### PR TITLE
Enable UART wakes from deepsleep

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -308,17 +308,20 @@ impl<'a, M: Mode> Uart<'a, M> {
         let regs = T::info().regs;
 
         if tx.is_some() {
-            regs.fifocfg().modify(|_, w| w.emptytx().set_bit().enabletx().enabled().waketx().set_bit());
+            regs.fifocfg()
+                .modify(|_, w| w.emptytx().set_bit().enabletx().enabled().waketx().set_bit());
 
             // clear FIFO error
             regs.fifostat().write(|w| w.txerr().set_bit());
         }
 
         if rx.is_some() {
-            regs.fifocfg().modify(|_, w| w.emptyrx().set_bit().enablerx().enabled().wakerx().set_bit());
+            regs.fifocfg()
+                .modify(|_, w| w.emptyrx().set_bit().enablerx().enabled().wakerx().set_bit());
 
-            regs.fifotrig().modify(|_, w| unsafe{ w.rxlvlena().set_bit().rxlvl().bits(0) });
-            
+            regs.fifotrig()
+                .modify(|_, w| unsafe { w.rxlvlena().set_bit().rxlvl().bits(0) });
+
             // clear FIFO error
             regs.fifostat().write(|w| w.rxerr().set_bit());
         }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -308,15 +308,17 @@ impl<'a, M: Mode> Uart<'a, M> {
         let regs = T::info().regs;
 
         if tx.is_some() {
-            regs.fifocfg().modify(|_, w| w.emptytx().set_bit().enabletx().enabled());
+            regs.fifocfg().modify(|_, w| w.emptytx().set_bit().enabletx().enabled().waketx().set_bit());
 
             // clear FIFO error
             regs.fifostat().write(|w| w.txerr().set_bit());
         }
 
         if rx.is_some() {
-            regs.fifocfg().modify(|_, w| w.emptyrx().set_bit().enablerx().enabled());
+            regs.fifocfg().modify(|_, w| w.emptyrx().set_bit().enablerx().enabled().wakerx().set_bit());
 
+            regs.fifotrig().modify(|_, w| unsafe{ w.rxlvlena().set_bit().rxlvl().bits(0) });
+            
             // clear FIFO error
             regs.fifostat().write(|w| w.rxerr().set_bit());
         }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -309,7 +309,7 @@ impl<'a, M: Mode> Uart<'a, M> {
 
         if tx.is_some() {
             regs.fifocfg()
-                .modify(|_, w| w.emptytx().set_bit().enabletx().enabled().waketx().set_bit());
+                .modify(|_, w| w.emptytx().set_bit().enabletx().enabled().waketx().enabled());
 
             // clear FIFO error
             regs.fifostat().write(|w| w.txerr().set_bit());
@@ -317,10 +317,10 @@ impl<'a, M: Mode> Uart<'a, M> {
 
         if rx.is_some() {
             regs.fifocfg()
-                .modify(|_, w| w.emptyrx().set_bit().enablerx().enabled().wakerx().set_bit());
+                .modify(|_, w| w.emptyrx().set_bit().enablerx().enabled().wakerx().enabled());
 
             regs.fifotrig()
-                .modify(|_, w| unsafe { w.rxlvlena().set_bit().rxlvl().bits(0) });
+                .modify(|_, w| unsafe { w.rxlvl().bits(0) }.rxlvlena().set_bit());
 
             // clear FIFO error
             regs.fifostat().write(|w| w.rxerr().set_bit());


### PR DESCRIPTION
In order to support waking and sending/receiving UART data reliably in DeepSleep power states, additional registers need to be configured at the UART layer. If corresponding bits are enabled in the SYSCTL0 HWWAKE register, peripherals will be allowed to continue clocking and receive data while the system is in DeepSleep.