### PR TITLE
Fix clippy check job and fix up examples

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo fmt --check
         working-directory: ${{ matrix.workdir }}
 
-  clippy:
+  clippy-examples:
     runs-on: ubuntu-latest
     name: ${{ matrix.toolchain }} / clippy
 
@@ -77,11 +77,9 @@ jobs:
           components: clippy
 
       - name: cargo clippy
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-review'
-          clippy_flags: -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
-          workdir: ${{ matrix.workdir }}
+        working-directory: ${{ matrix.example_directory }}
+        run: |
+          cargo clippy --target thumbv8m.main-none-eabihf --locked -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
 
   # Enable once we have a released crate
   # semver:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
-        toolchain: [stable, beta]
+        toolchain: [stable]
         workdir: ["examples/rt633", "examples/rt685s-evk"]
 
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,7 @@ jobs:
           components: clippy
 
       - name: cargo clippy
-        working-directory: ${{ matrix.example_directory }}
+        working-directory: ${{ matrix.workdir }}
         run: |
           cargo clippy --locked -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
-        workdir: [ ".", "examples/rt633", "examples/rt685s-evk"]
+        workdir: ["examples/rt633", "examples/rt685s-evk"]
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
       - name: cargo clippy
         working-directory: ${{ matrix.example_directory }}
         run: |
-          cargo clippy --target thumbv8m.main-none-eabihf --locked -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
+          cargo clippy --locked -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
 
   # Enable once we have a released crate
   # semver:

--- a/ci.sh
+++ b/ci.sh
@@ -120,8 +120,8 @@ FEATURE_COMBINATIONS=(
 )
 cargo batch \
       $(for features in "${FEATURE_COMBINATIONS[@]}"; do
-	  echo "--- build --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
-	  echo "--- build --locked --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
+	  echo "--- build --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
+	  echo "--- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
 	done) $BUILD_EXTRA
 
 cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-os-timer,unstable-pac" -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style

--- a/ci.sh
+++ b/ci.sh
@@ -120,6 +120,9 @@ FEATURE_COMBINATIONS=(
 )
 cargo batch \
       $(for features in "${FEATURE_COMBINATIONS[@]}"; do
-	  echo "--- build --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
-	  echo "--- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
+	  echo "--- build --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
+	  echo "--- build --locked --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
 	done) $BUILD_EXTRA
+
+cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-os-timer,unstable-pac" -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
+cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-rtc,unstable-pac" -- -Dwarnings -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "embedded-mcu-hal"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#21f07f4497bee540d6957f37ac7759887f00a430"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
 dependencies = [
  "defmt 1.0.1",
 ]
@@ -753,7 +753,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#21f07f4497bee540d6957f37ac7759887f00a430"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
 
 [[package]]
 name = "strsim"

--- a/examples/rt633/src/bin/espi.rs
+++ b/examples/rt633/src/bin/espi.rs
@@ -94,14 +94,14 @@ async fn main(_spawner: Spawner) {
                     "eSPI PeripheralEvent Port: {}, direction: {}, address: {}, offset: {}, length: {}",
                     port_event.port, port_event.direction, port_event.offset, port_event.base_addr, port_event.length,
                 );
-                espi.complete_port(port_event.port).await;
+                espi.complete_port(port_event.port);
             }
             Ok(Event::OOBEvent(port_event)) => {
                 info!(
                     "eSPI OOBEvent Port: {}, direction: {}, address: {}, offset: {}, length: {}",
                     port_event.port, port_event.direction, port_event.offset, port_event.base_addr, port_event.length,
                 );
-                espi.complete_port(port_event.port).await;
+                espi.complete_port(port_event.port);
             }
             Ok(Event::WireChange(event)) => {
                 info!("Wire Change! {}", event);

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -35,7 +35,6 @@ async fn main(_spawner: Spawner) {
 
     // Acc is connected to P0_18_FC2_SCL and P0_17_FC2_SDA for I2C
     // Acc RESET gpio is P1_7_RST
-    info!("i2c example - embassy_imxrt::init");
     let p = embassy_imxrt::init(Default::default());
 
     info!("i2c example - Configure GPIOs");

--- a/src/espi.rs
+++ b/src/espi.rs
@@ -435,10 +435,7 @@ pub enum BootStatus {
 
 impl From<BootStatus> for bool {
     fn from(status: BootStatus) -> bool {
-        match status {
-            BootStatus::Success => true,
-            _ => false,
-        }
+        matches!(status, BootStatus::Success)
     }
 }
 
@@ -451,6 +448,7 @@ pub struct Espi<'d> {
 
 impl<'d> Espi<'d> {
     /// Instantiates new eSPI peripheral and initializes to default values.
+    #[allow(clippy::too_many_arguments)]
     pub fn new<T: Instance>(
         _peripheral: Peri<'d, T>,
         _clk: Peri<'d, impl ClkPin<T>>,
@@ -830,7 +828,8 @@ impl<'d> Espi<'d> {
     /// Warning: This directly returns memory buffer based on port config, memory.x
     /// must have memory properly carved out to prevent back access
     ///
-    /// SAFETY: OOB port config must point to valid memory region that has been carved
+    /// # Safety
+    /// OOB port config must point to valid memory region that has been carved
     /// out in memory.x to prevent access to code region. After calling oob_write_data
     /// must wait for Event::OOBEvent with direction: true to indicate previous write
     /// has completed. Not waiting for previous transaction can lead to corruption of

--- a/src/espi.rs
+++ b/src/espi.rs
@@ -675,9 +675,7 @@ impl<'d> Espi<'d> {
                     direction,
                 })))
             }
-            _ => {
-                Poll::Pending
-            }
+            _ => Poll::Pending,
         }
     }
 

--- a/src/espi.rs
+++ b/src/espi.rs
@@ -187,9 +187,9 @@ pub enum PortConfig {
     MasterFlash,
 }
 
-impl Into<Type> for PortConfig {
-    fn into(self) -> Type {
-        match self {
+impl From<PortConfig> for Type {
+    fn from(val: PortConfig) -> Self {
+        match val {
             PortConfig::Unconfigured => Type::Unconfigured,
             PortConfig::AcpiEndpoint { .. } => Type::AcpiEnd,
             PortConfig::AcpiIndex => Type::AcpiIndex,
@@ -478,7 +478,7 @@ impl<'d> Espi<'d> {
 
         let mut instance = Espi::<'d> {
             info: T::info(),
-            config: config,
+            config,
             _phantom: PhantomData,
         };
 
@@ -658,25 +658,25 @@ impl<'d> Espi<'d> {
                 };
 
                 Poll::Ready(Ok(Event::PeripheralEvent(PortEvent {
-                    port: port,
+                    port,
                     base_addr: address,
                     offset: idxoff,
-                    length: length,
-                    direction: direction,
+                    length,
+                    direction,
                 })))
             }
             PortConfig::MailboxSplitOOB { offset, .. } => {
                 let address = self.config.ram_base + offset as u32;
                 Poll::Ready(Ok(Event::OOBEvent(PortEvent {
-                    port: port,
+                    port,
                     base_addr: address,
                     offset: 0,
-                    length: length,
-                    direction: direction,
+                    length,
+                    direction,
                 })))
             }
             _ => {
-                return Poll::Pending;
+                Poll::Pending
             }
         }
     }

--- a/src/flexspi/nor.rs
+++ b/src/flexspi/nor.rs
@@ -459,6 +459,7 @@ impl From<FlexSpiError> for NorStorageBusError {
 
 impl FlexSpiError {
     /// Get the description of the error
+    #[cfg(feature = "defmt")]
     pub fn describe<M: Mode>(&self, flexspi: &FlexspiNorStorageBus<M>) {
         match self {
             FlexSpiError::CmdGrantErr { result } => {
@@ -619,6 +620,7 @@ impl BlockingNorStorageBusDriver for FlexspiNorStorageBus<'_, Blocking> {
 
         // Check for any errors during the transfer
         self.check_transfer_status().map_err(|e| {
+            #[cfg(feature = "defmt")]
             e.describe(self);
             <FlexSpiError as Into<FlexSpiError>>::into(e)
         })?;
@@ -1036,8 +1038,9 @@ impl FlexspiNorStorageBus<'_, Blocking> {
 
         let error = self.check_transfer_status();
 
-        if let Err(e) = error {
-            e.describe(self);
+        if let Err(_e) = error {
+            #[cfg(feature = "defmt")]
+            _e.describe(self);
             return Err(NorStorageBusError::StorageBusIoError);
         }
 
@@ -1092,8 +1095,9 @@ impl FlexspiNorStorageBus<'_, Blocking> {
     fn write_cmd_data(&mut self, write_data: &[u8]) -> Result<(), NorStorageBusError> {
         // Check for any errors during the transfer
         let error = self.check_transfer_status();
-        if let Err(e) = error {
-            e.describe(self);
+        if let Err(_e) = error {
+            #[cfg(feature = "defmt")]
+            _e.describe(self);
             return Err(NorStorageBusError::StorageBusIoError);
         }
 
@@ -1148,6 +1152,7 @@ impl FlexspiNorStorageBus<'_, Blocking> {
 
 impl FlexSpiConfigurationPort {
     /// Initialize FlexSPI
+    #[allow(clippy::result_unit_err)]
     pub fn configure_flexspi(&mut self, config: &FlexspiConfig) -> Result<(), ()> {
         let regs = self.info.regs;
 
@@ -1332,6 +1337,7 @@ impl FlexSpiConfigurationPort {
     }
 
     /// Configure the flash self.flexspi_ref based on the external flash device
+    #[allow(clippy::result_unit_err)]
     pub fn configure_device_port(
         &self,
         device_config: &FlexspiDeviceConfig,
@@ -1552,6 +1558,7 @@ impl<'d> FlexspiNorStorageBus<'d, Blocking> {
     }
 
     /// Create a new FlexSPI instance in blocking mode with octal configuration
+    #[allow(clippy::too_many_arguments)]
     pub fn new_blocking_octal_config<T: Instance>(
         _inst: Peri<'d, T>,
         data0: Peri<'d, impl FlexSpiPin>,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -945,7 +945,7 @@ impl embedded_hal_1::digital::StatefulOutputPin for Flex<'_, SenseEnabled> {
     }
 }
 
-impl<'d> embedded_hal_async::digital::Wait for Flex<'d, SenseEnabled> {
+impl embedded_hal_async::digital::Wait for Flex<'_, SenseEnabled> {
     #[inline]
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         self.wait_for_high().await;
@@ -993,7 +993,7 @@ impl embedded_hal_1::digital::InputPin for Input<'_> {
     }
 }
 
-impl<'d> embedded_hal_async::digital::Wait for Input<'d> {
+impl embedded_hal_async::digital::Wait for Input<'_> {
     #[inline]
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         self.wait_for_high().await;

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -316,7 +316,7 @@ impl<'a> I2cMaster<'a, Blocking> {
 
         i2cregs.mstdat().write(|w|
             // SAFETY: only unsafe due to .bits usage
-            unsafe { w.data().bits(address << 1 | u8::from(is_read)) });
+            unsafe { w.data().bits((address << 1) | u8::from(is_read)) });
 
         i2cregs.mstctl().write(|w| w.mststart().set_bit());
 
@@ -557,7 +557,7 @@ impl<'a> I2cMaster<'a, Async> {
 
         i2cregs.mstdat().write(|w|
             // SAFETY: only unsafe due to .bits usage
-            unsafe { w.data().bits(address << 1 | u8::from(is_read)) });
+            unsafe { w.data().bits((address << 1) | u8::from(is_read)) });
 
         i2cregs.mstctl().write(|w| w.mststart().set_bit());
 

--- a/src/time_driver/ostimer.rs
+++ b/src/time_driver/ostimer.rs
@@ -93,8 +93,7 @@ impl OsTimer {
 
         let gray_timestamp = dec_to_gray(timestamp);
 
-        os().match_l()
-            .write(|w| unsafe { w.bits(gray_timestamp as u32 & 0xffff_ffff) });
+        os().match_l().write(|w| unsafe { w.bits(gray_timestamp as u32) });
         os().match_h()
             .write(|w| unsafe { w.bits((gray_timestamp >> 32) as u32) });
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -516,7 +516,7 @@ impl From<TriggerInput> for crate::pac::inputmux::ct32bit_cap::ct32bit_cap_sel::
     }
 }
 
-impl<'p, M: Mode, P: CaptureEvent> CaptureTimer<'p, M, P> {
+impl<M: Mode, P: CaptureEvent> CaptureTimer<'_, M, P> {
     /// Returns the captured clock count
     /// Captured clock = (Capture value - previous counter value)
     fn get_event_capture_time_us(&self) -> u32 {
@@ -759,9 +759,9 @@ impl<M: Mode> CountingTimer<M> {
     }
 }
 
-impl<'p> CountingTimer<Async> {
+impl CountingTimer<Async> {
     /// Creates a new `CountingTimer` in asynchronous mode.
-    pub fn new_async<T: Instance>(_inst: Peri<'p, T>, clk: impl ConfigurableClock) -> Self {
+    pub fn new_async<T: Instance>(_inst: Peri<'_, T>, clk: impl ConfigurableClock) -> Self {
         let info = T::info();
         T::interrupt_enable();
         Self {
@@ -790,9 +790,9 @@ impl<'p> CountingTimer<Async> {
     }
 }
 
-impl<'p> CountingTimer<Blocking> {
+impl CountingTimer<Blocking> {
     /// Creates a new `CountingTimer` in blocking mode.
-    pub fn new_blocking<T: Instance>(_inst: Peri<'p, T>, clk: impl ConfigurableClock) -> Self {
+    pub fn new_blocking<T: Instance>(_inst: Peri<'_, T>, clk: impl ConfigurableClock) -> Self {
         let info = T::info();
         T::interrupt_enable();
         Self {
@@ -826,7 +826,7 @@ impl<M: Mode> Drop for CountingTimer<M> {
     }
 }
 
-impl<'p, M: Mode, P: CaptureEvent> Drop for CaptureTimer<'p, M, P> {
+impl<M: Mode, P: CaptureEvent> Drop for CaptureTimer<'_, M, P> {
     fn drop(&mut self) {
         self.info.cap_timer_interrupt_disable();
         self.info.cap_timer_disable_falling_edge_event();


### PR DESCRIPTION
Clippy workflow was not checking errors and failing silently, and it let a bunch of clippy errors through.

- Rework the clippy check job because of the silent failure and `embassy-imxrt` needs to have chip feature defined to compile correctly.
- Fix up all the clippy errors.
- Fix up another example that traces before initialization of `embassy-imxrt`