### PR TITLE
Remove dependency on defmt from embassy-imxrt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ defmt = [
     "dep:defmt",
     "embassy-hal-internal/defmt",
     "embassy-sync/defmt",
+    "embedded-mcu-hal/defmt",
     "mimxrt685s-pac?/defmt",
     "mimxrt633s-pac?/defmt",
 ]
@@ -109,7 +110,7 @@ embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
 
-embedded-mcu-hal = { git = "https://github.com/OpenDevicePartnership/embedded-mcu" }
+embedded-mcu-hal = { git = "https://github.com/OpenDevicePartnership/embedded-mcu", default-features = false }
 mimxrt600-fcb = "0.2.0"
 document-features = "0.2.7"
 paste = "1.0"


### PR DESCRIPTION
Embedded-mcu-hal has the default feature 'defmt' enabled. We are using the default feature set of this crate, hence we have a dependency on defmt for this crate as well.

This PR removes this dependency and adds it to the defmt feature instead.