### PR TITLE
Remove waketx on UART FIFO

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -309,7 +309,7 @@ impl<'a, M: Mode> Uart<'a, M> {
 
         if tx.is_some() {
             regs.fifocfg()
-                .modify(|_, w| w.emptytx().set_bit().enabletx().enabled().waketx().enabled());
+                .modify(|_, w| w.emptytx().set_bit().enabletx().enabled());
 
             // clear FIFO error
             regs.fifostat().write(|w| w.txerr().set_bit());
@@ -324,6 +324,8 @@ impl<'a, M: Mode> Uart<'a, M> {
 
             // clear FIFO error
             regs.fifostat().write(|w| w.rxerr().set_bit());
+        
+
         }
 
         if rts.is_some() && cts.is_some() {

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -308,8 +308,7 @@ impl<'a, M: Mode> Uart<'a, M> {
         let regs = T::info().regs;
 
         if tx.is_some() {
-            regs.fifocfg()
-                .modify(|_, w| w.emptytx().set_bit().enabletx().enabled());
+            regs.fifocfg().modify(|_, w| w.emptytx().set_bit().enabletx().enabled());
 
             // clear FIFO error
             regs.fifostat().write(|w| w.txerr().set_bit());
@@ -324,8 +323,6 @@ impl<'a, M: Mode> Uart<'a, M> {
 
             // clear FIFO error
             regs.fifostat().write(|w| w.rxerr().set_bit());
-        
-
         }
 
         if rts.is_some() && cts.is_some() {


### PR DESCRIPTION
Adding the waketx bit is causing the UART peripheral to stay always clocked, increasing power consumption on the MCU by ~10mW. Waking on DMA TX is not needed for any current designs, so it is being disabled.