### PR TITLE
Async passthough

### DIFF
--- a/src/dma/channel.rs
+++ b/src/dma/channel.rs
@@ -1,8 +1,6 @@
 //! DMA channel & request
 
-use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::task::Poll;
 
 use embassy_sync::waitqueue::AtomicWaker;
 
@@ -35,15 +33,13 @@ impl<'d> Channel<'d> {
     }
 
     /// Writes from a memory buffer to another memory buffer
-    pub async fn write_to_memory(
+    pub fn write_to_memory(
         &'d self,
         src_buf: &'d [u8],
         dst_buf: &'d mut [u8],
         options: TransferOptions,
     ) -> Transfer<'d> {
-        let transfer = Transfer::new_write_mem(self, src_buf, dst_buf, options);
-        self.poll_transfer_complete().await;
-        transfer
+        Transfer::new_write_mem(self, src_buf, dst_buf, options)
     }
 
     /// Return a reference to the channel's waker
@@ -78,30 +74,6 @@ impl<'d> Channel<'d> {
         self.info.regs.abort0().write(|w|
             // SAFETY: unsafe due to .bits usage
             unsafe { w.bits(1 << channel) });
-    }
-
-    async fn poll_transfer_complete(&'d self) {
-        poll_fn(|cx| {
-            // TODO - handle transfer failure
-
-            let channel = self.info.ch_num;
-
-            // Has the transfer already completed?
-            // TODO: Is this necessary? We could check once after registration
-            if self.info.regs.active0().read().act().bits() & (1 << channel) == 0 {
-                return Poll::Ready(());
-            }
-
-            DMA_WAKERS[channel].register(cx.waker());
-
-            // Has the transfer completed now?
-            if self.info.regs.active0().read().act().bits() & (1 << channel) == 0 {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        })
-        .await;
     }
 
     /// Prepare the DMA channel for the transfer

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -290,35 +290,35 @@ impl<'d> Flex<'d, SenseEnabled> {
 
     /// Wait until the pin is high. If it is already high, return immediately.
     #[inline]
-    pub async fn wait_for_high(&mut self) {
-        InputFuture::new(self.pin.reborrow(), InterruptType::Level, Level::High).await;
+    pub fn wait_for_high(&mut self) -> InputFuture<'_> {
+        InputFuture::new(self.pin.reborrow(), InterruptType::Level, Level::High)
     }
 
     /// Wait until the pin is low. If it is already low, return immediately.
     #[inline]
-    pub async fn wait_for_low(&mut self) {
-        InputFuture::new(self.pin.reborrow(), InterruptType::Level, Level::Low).await;
+    pub fn wait_for_low(&mut self) -> InputFuture<'_> {
+        InputFuture::new(self.pin.reborrow(), InterruptType::Level, Level::Low)
     }
 
     /// Wait for the pin to undergo a transition from low to high.
     #[inline]
-    pub async fn wait_for_rising_edge(&mut self) {
-        InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::High).await;
+    pub fn wait_for_rising_edge(&mut self) -> InputFuture<'_> {
+        InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::High)
     }
 
     /// Wait for the pin to undergo a transition from high to low.
     #[inline]
-    pub async fn wait_for_falling_edge(&mut self) {
-        InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::Low).await;
+    pub fn wait_for_falling_edge(&mut self) -> InputFuture<'_> {
+        InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::Low)
     }
 
     /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
     #[inline]
-    pub async fn wait_for_any_edge(&mut self) {
+    pub fn wait_for_any_edge(&mut self) -> InputFuture<'_> {
         if self.is_high() {
-            InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::Low).await;
+            InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::Low)
         } else {
-            InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::High).await;
+            InputFuture::new(self.pin.reborrow(), InterruptType::Edge, Level::High)
         }
     }
 
@@ -390,37 +390,38 @@ impl<'d> Input<'d> {
 
     /// Wait until the pin is high. If it is already high, return immediately.
     #[inline]
-    pub async fn wait_for_high(&mut self) {
-        self.pin.wait_for_high().await;
+    pub fn wait_for_high(&mut self) -> InputFuture<'_> {
+        self.pin.wait_for_high()
     }
 
     /// Wait until the pin is low. If it is already low, return immediately.
     #[inline]
-    pub async fn wait_for_low(&mut self) {
-        self.pin.wait_for_low().await;
+    pub fn wait_for_low(&mut self) -> InputFuture<'_> {
+        self.pin.wait_for_low()
     }
 
     /// Wait for the pin to undergo a transition from low to high.
     #[inline]
-    pub async fn wait_for_rising_edge(&mut self) {
-        self.pin.wait_for_rising_edge().await;
+    pub fn wait_for_rising_edge(&mut self) -> InputFuture<'_> {
+        self.pin.wait_for_rising_edge()
     }
 
     /// Wait for the pin to undergo a transition from high to low.
     #[inline]
-    pub async fn wait_for_falling_edge(&mut self) {
-        self.pin.wait_for_falling_edge().await;
+    pub fn wait_for_falling_edge(&mut self) -> InputFuture<'_> {
+        self.pin.wait_for_falling_edge()
     }
 
     /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
     #[inline]
-    pub async fn wait_for_any_edge(&mut self) {
-        self.pin.wait_for_any_edge().await;
+    pub fn wait_for_any_edge(&mut self) -> InputFuture<'_> {
+        self.pin.wait_for_any_edge()
     }
 }
 
+/// A gpio future to be awaited
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-struct InputFuture<'d> {
+pub struct InputFuture<'d> {
     pin: Peri<'d, AnyPin>,
 }
 


### PR DESCRIPTION
With some refactoring we can be smarter than the compiler (which isn't too smart when it comes to async).
This saves some flash!

I don't know how much in a *real* application, but all examples combined save ~4.5kB.

Al behavior and public APIs should still be the same except for the one in dma/channel.rs, but that one will be an obvious refactor if that breaks anyone.