### PR TITLE
Fix issue that can lead to i2c clock frequency exceeding spec

### DIFF
--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -124,6 +124,9 @@ impl SpeedRegisterSettings {
                     rounded_divide(SFRO_CLOCK_SPEED_HZ, target_freq_hz * u32::from(hi_clocks + lo_clocks)) as u16;
                 (hi_clocks, lo_clocks, clock_div_multiplier)
             })
+            .filter(|(hi_clocks, lo_clocks, clock_div_multiplier)| {
+                get_freq_hz(*hi_clocks, *lo_clocks, *clock_div_multiplier, SFRO_CLOCK_SPEED_HZ) <= target_freq_hz
+            })
             .min_by(|a, b| {
                 let (hi_a, lo_a, div_a) = a;
                 let (hi_b, lo_b, div_b) = b;


### PR DESCRIPTION
The i2c hardware doesn't support much precision in selecting duty cycles - we only have six bits to use to determine the duty cycle, and then we have to come up with a 'clock divider' that hits the target speed as closely as possible. In cases where that math doesn't divide precisely, we need to select the closest clock divider that doesn't exceed the max speed.  However, the current implementation just selects the clock divider that minimizes the difference between target frequency and actual frequency, without regard for which side of the target frequency that error lands on.
This change removes clock speeds that would exceed the spec from consideration for best fit so we don't violate the spec.