### PR TITLE
I2c: use lowest pre-divider possible

### DIFF
--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -126,7 +126,14 @@ impl SpeedRegisterSettings {
                 (hi_clocks, lo_clocks, clock_div_multiplier)
             })
             .filter(|(hi_clocks, lo_clocks, clock_div_multiplier)| {
-                get_freq_hz(*hi_clocks, *lo_clocks, *clock_div_multiplier, CLOCK_SPEED_HZ) <= target_freq_hz
+                // Require the resulting frequency to be strictly below `target_freq_hz`.
+                //
+                // This is necessary because hardware clock dividers and scalers can introduce
+                // rounding errors or imprecisions, causing the actual I2C clock to slightly exceed
+                // the calculated value. By enforcing a strict inequality, we ensure that the actual
+                // I2C clock frequency will not exceed the requested maximum, which is important for
+                // I2C compliance and to avoid violating timing requirements of connected devices.
+                get_freq_hz(*hi_clocks, *lo_clocks, *clock_div_multiplier, CLOCK_SPEED_HZ) < target_freq_hz
             })
             .min_by(|a, b| {
                 let (hi_a, lo_a, div_a) = a;


### PR DESCRIPTION
By using lowest possible pre-divider with highest possible `HIGH` and `LOW` counts, we achieve a much more stable I2C clock.