### PR TITLE
I2C: Allow exact frequency matches

### DIFF
--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -129,14 +129,7 @@ impl SpeedRegisterSettings {
                 (hi_clocks, lo_clocks, clock_div_multiplier)
             })
             .filter(|(hi_clocks, lo_clocks, clock_div_multiplier)| {
-                // Require the resulting frequency to be strictly below `target_freq_hz`.
-                //
-                // This is necessary because hardware clock dividers and scalers can introduce
-                // rounding errors or imprecisions, causing the actual I2C clock to slightly exceed
-                // the calculated value. By enforcing a strict inequality, we ensure that the actual
-                // I2C clock frequency will not exceed the requested maximum, which is important for
-                // I2C compliance and to avoid violating timing requirements of connected devices.
-                get_freq_hz(*hi_clocks, *lo_clocks, *clock_div_multiplier, CLOCK_SPEED_HZ) < target_freq_hz
+                get_freq_hz(*hi_clocks, *lo_clocks, *clock_div_multiplier, CLOCK_SPEED_HZ) <= target_freq_hz
             })
             .min_by(|(hi_a, lo_a, div_a), (hi_b, lo_b, div_b)| {
                 let freq_a = get_freq_hz(*hi_a, *lo_a, *div_a, CLOCK_SPEED_HZ);


### PR DESCRIPTION
41f9d4d221cc60a16527f6afb38b908689468f50 made a change to filter out configurations that had a duty cycle of exactly the target frequency in an attempt to add a little buffer so that jitter wouldn't cause overshoot of the target frequency. This works at a duty cycle of 50% where there exists a (high_clocks, low_clocks, clock_div) tuple that satisfies this due to rounding error, e.g. (9, 9, 7) => 380952. However, this had the unintended side-effect of causing any duty cycles that do not incur rounding error at any point to be rejected - i.e. it's impossible to configure a 40% duty cycle at 100kHz because the candidates all divide cleanly.

This change reverts to allowing direct matches to enable these duty cycles. Clients that need strict compliance can use strict_mode: true to achieve it.