### PR TITLE
Fixed derivable_impls lint that was breaking CI since 1.91

### DIFF
--- a/src/espi.rs
+++ b/src/espi.rs
@@ -98,9 +98,10 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 }
 
 /// eSPI Port configuration.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PortConfig {
     /// Unconfigured
+    #[default]
     Unconfigured,
 
     /// ACPI-style Endpoint
@@ -202,12 +203,6 @@ impl From<PortConfig> for Type {
             PortConfig::MemSingle => Type::BusMMemS,
             PortConfig::MasterFlash => Type::BusMFlashS,
         }
-    }
-}
-
-impl Default for PortConfig {
-    fn default() -> Self {
-        Self::Unconfigured
     }
 }
 


### PR DESCRIPTION
Since 1.91 was released we are getting the following error on CI:
```
Checking embassy-imxrt v0.1.0 (/home/runner/work/embassy-imxrt/embassy-imxrt)
error: this `impl` can be derived
   --> src/espi.rs:208:1
    |
208 | / impl Default for PortConfig {
209 | |     fn default() -> Self {
210 | |         Self::Unconfigured
211 | |     }
212 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#derivable_impls
    = note: `-D clippy::derivable-impls` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::derivable_impls)]`
help: replace the manual implementation with a derive attribute and mark the default variant
    |
102 + #[derive(Default)]
103 ~ pub enum PortConfig {
104 |     /// Unconfigured
105 ~     #[default]
106 ~     Unconfigured,
    |
```

This PR fixes this lint. 