### PR TITLE
Audit DMA HAL

### DIFF
--- a/src/dma/transfer.rs
+++ b/src/dma/transfer.rs
@@ -178,7 +178,7 @@ impl Future for Transfer<'_> {
 
         // Re-register the waker on each call to poll() because any calls to
         // wake will deregister the waker.
-        super::DMA_WAKERS[channel].register(cx.waker());
+        self._inner.get_waker().register(cx.waker());
 
         if self._inner.info.regs.active0().read().act().bits() & (1 << channel) == 0 {
             Poll::Ready(())


### PR DESCRIPTION
I don't believe it will be easy to remove the static WAKER and DESCRIPTOR arrays.

In the waker case, since each DMA channel is not a separate peripheral with its own IRQ handler, the ISR needs a way to associate a raw channel number with a waker, and this is fallible at runtime. But instead, have the ISR just silently skip attempting to wake a channel instance if somehow a waker is not registered with it. Additionally add a reference into the static WAKERS array for each channel so at least they don't have to index.

DESCRIPTOR is a bit more troublesome. This also needs to be static since the DMA peripheral requires the descriptor base address be at a fixed 1024 byte aligned location. If we do something similar to the waker and try to store a reference to the descriptor in the info struct to avoid indexing, this gets complicated since we need to store a mutable reference (for use in `configure_channel`) which breaks the API as now we need `&mut self`. The `configure_channel` method also currently explicitly panics on invalid mem_len, and as far as I can see there is no way to guarantee this statically, so we either have to panic or return an error (or silently induce undefined behavior).

Currently draft to get some thoughts on how we want to approach `configure_channel` as returning an error and taking a `&mut self` (or just attempt to index DESCRIPTORS via `get_mut` and returning an error so only the change in return type is something we have to worry about) is going to break not only other drivers in the HAL depending on it, but also all application code depending on those drivers. Seems like a pretty significant breaking change.

@gjpmsft @jerrysxie Do we want to commit to breaking the API and the work that entails?

Resolves https://github.com/OpenDevicePartnership/embedded-services/issues/631