### PR TITLE
Fixed regression in main related to async i2c slave after enabling checks for unwrap

### DIFF
--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -255,8 +255,8 @@ impl<'a> I2cSlave<'a, Async> {
     ) -> Result<Self> {
         let ch = dma::Dma::reserve_channel(dma_ch);
 
-        if ch.is_some() {
-            let this = Self::new_inner::<T>(_bus, scl, sda, address, Some(ch.unwrap()))?;
+        if let Some(ch) = ch {
+            let this = Self::new_inner::<T>(_bus, scl, sda, address, Some(ch))?;
 
             T::Interrupt::unpend();
             unsafe { T::Interrupt::enable() };


### PR DESCRIPTION
After merging main into #507 CI failed on a remaining `unwrap` in the codebase.