### PR TITLE
Audit timers HAL #3: Remove unwraps

### DIFF
--- a/examples/rt685s-evk/src/bin/timer.rs
+++ b/examples/rt685s-evk/src/bin/timer.rs
@@ -31,10 +31,10 @@ async fn main(spawner: Spawner) {
     spawner.spawn(monitor_task()).unwrap();
 
     let sfro = ClockConfig::crystal().sfro;
-    let mut tmr1 = CountingTimer::new_blocking(p.CTIMER0_COUNT_CHANNEL0, sfro);
+    let mut tmr1 = CountingTimer::new_blocking(p.CTIMER0_COUNT_CHANNEL0, sfro).expect("Invalid clock config");
 
     let sfro = ClockConfig::crystal().sfro;
-    let mut tmr2 = CountingTimer::new_async(p.CTIMER1_COUNT_CHANNEL0, sfro, Irqs);
+    let mut tmr2 = CountingTimer::new_async(p.CTIMER1_COUNT_CHANNEL0, sfro, Irqs).expect("Invalid clock config");
 
     tmr1.wait_us(3000000); // 3 seoconds wait
     info!("First Counting timer expired");
@@ -45,7 +45,8 @@ async fn main(spawner: Spawner) {
     {
         let sfro = ClockConfig::crystal().sfro;
         let mut cap_async_tmr =
-            CaptureTimer::new_async(p.CTIMER4_CAPTURE_CHANNEL0.reborrow(), p.PIO0_5.reborrow(), sfro, Irqs);
+            CaptureTimer::new_async(p.CTIMER4_CAPTURE_CHANNEL0.reborrow(), p.PIO0_5.reborrow(), sfro, Irqs)
+                .expect("Invalid clock config");
         let event_time_us = cap_async_tmr.capture_cycle_time_us(CaptureChEdge::Rising).await;
         info!("Capture timer expired, time between two capture = {} us", event_time_us);
 
@@ -53,7 +54,8 @@ async fn main(spawner: Spawner) {
 
         let sfro = ClockConfig::crystal().sfro;
         let mut cap_async_tmr =
-            CaptureTimer::new_async(p.CTIMER4_CAPTURE_CHANNEL0.reborrow(), p.PIO0_5.reborrow(), sfro, Irqs);
+            CaptureTimer::new_async(p.CTIMER4_CAPTURE_CHANNEL0.reborrow(), p.PIO0_5.reborrow(), sfro, Irqs)
+                .expect("Invalid clock config");
         let event_time_us = cap_async_tmr.capture_cycle_time_us(CaptureChEdge::Rising).await;
         info!("Capture timer expired, time between two capture = {} us", event_time_us);
     }


### PR DESCRIPTION
Depends on #531 
Resolves #530 

This removes the last of the panic paths in the timers HAL by removing unwraps and changing a few constructors to return a `Result` instead (which introduces a breaking change). A new freq field was added to the PWM struct since originally, we unwrapped in a PWM trait method which does not return a `Result`. So, we just verify the clock config is valid in the constructor and can use the cached freq in the trait methods.