### PR TITLE
Add input buffer enable/disable support.

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -190,6 +190,16 @@ impl<S: Sense> Flex<'_, S> {
             unsafe { w.dirsetp().bits(1 << self.pin.pin()) });
     }
 
+    /// Set the input buffer state
+    ///
+    pub fn set_input_buffer(&mut self, enable: bool) {
+        if enable {
+            self.pin.enable_input_buffer();
+        } else {
+            self.pin.disable_input_buffer();
+        }
+    }
+
     /// Set high
     pub fn set_high(&mut self) {
         self.pin.block().set(self.pin.port()).write(|w|


### PR DESCRIPTION
Add a new function to set input buffer (enable/disable) for power saving. For Surface products, gpio configured as output pin should has input buffer disabled in deep doze.
<img width="661" height="94" alt="image" src="https://github.com/user-attachments/assets/202c92d6-1b00-4c12-b78b-82a6570087d6" />
