### PR TITLE
Audit flexspi HAL for panics

### DIFF
--- a/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
+++ b/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
@@ -419,7 +419,8 @@ async fn main(_spawner: Spawner) {
             rx_watermark: 0x8,
             tx_watermark: 0x8,
         },
-    );
+    )
+    .unwrap_or_else(|_| panic!("Invalid config"));
 
     // Configure the Flexspi controller
     let _ = flexspi_storage.configport.configure_flexspi(&flexspi_config); // Configure the Flexspi controller


### PR DESCRIPTION
Removes unwraps and most indexing/slicing (two cases of slicing were left in but are very easy to see they can never panic) from the flexspi HAL.

I use this pattern several times for copying a remainder (which may be less than a 4 byte chunk):

```rust
for (to, from) in remainder.iter_mut().zip(data.to_le_bytes().iter()) {
    *to = *from;
}
```

since it avoids the need to use `copy_from_slice` (with a calculated min length). However, this may be slightly less efficient than the equivalent `copy_from_slice` especially since the compiler should be able to elide the panic path as remainder size can be determined statically (`as_chunks::<N>` guarantees statically that remainder length is less than N). Open to using the slice method with an `allow` lint if folks prefer.

# Testing
The changes in `peripheral.rs` I was able to test by copying the unit tests to another project with my new implementations and verifying they pass (speaking of, I can't figure out how to get `cargo test` to work here).

My other changes I at least tested using the `flexspi-embedded-storage` and `flexspi-nor-flash` examples on the 685evk. Still having issues getting the flexspi-nor-flash example working properly as I'm having trouble receiving defmt logs to verify it's functioning correctly.

Resolves https://github.com/OpenDevicePartnership/embedded-services/issues/643