### PR TITLE
Add panic lints to CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,17 @@ embedded-storage = "0.3.1"
 [dev-dependencies]
 embassy-executor = "0.9.0"
 static_cell = { version = "2" }
+
+[lints.clippy]
+correctness = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"
+panic_in_result_fn = "deny"
+perf = "deny"
+suspicious = "deny"
+style = "deny"
+todo = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+unwrap_used = "deny"

--- a/ci.sh
+++ b/ci.sh
@@ -124,5 +124,5 @@ cargo batch \
 	  echo "--- build --release --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features $features "
 	done) $BUILD_EXTRA
 
-cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-os-timer,unstable-pac" -- -Dwarnings -D clippy::suspicious -D clippy::correctness -D clippy::perf -D clippy::style
-cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-rtc,unstable-pac" -- -Dwarnings -D clippy::suspicious -D clippy::correctness -D clippy::perf -D clippy::style
+cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-os-timer,unstable-pac" -- -Dwarnings
+cargo clippy --locked --manifest-path Cargo.toml --target thumbv8m.main-none-eabihf --features "mimxrt633s,rt,time-driver-rtc,unstable-pac" -- -Dwarnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod crc;
 pub mod dma;
 
 #[cfg(feature = "_espi")]
+#[allow(clippy::indexing_slicing)]
 pub mod espi;
 
 pub mod flash;


### PR DESCRIPTION
This pull request introduces stricter Clippy lint enforcement at the project level and updates how Clippy lints are handled in the CI script. The main goal is to ensure code quality by denying a wide range of lints by default, while simplifying the Clippy invocation in CI. Additionally, a specific lint is suppressed for the `espi` module.

**Lint configuration improvements:**

* Added a `[lints.clippy]` section to `Cargo.toml` to deny several categories of Clippy lints globally, including `correctness`, `expect_used`, `indexing_slicing`, `panic`, `perf`, `suspicious`, `style`, `todo`, `unimplemented`, `unreachable`, and `unwrap_used`.

* Added `#[allow(clippy::indexing_slicing)]` to the `espi` module declaration in `src/lib.rs` to suppress this lint specifically for that module.

**CI configuration changes:**

* Simplified the Clippy invocation in `ci.sh` by removing explicit lint deny flags from the command line, relying instead on the lints configured in `Cargo.toml`.