### PR TITLE
Separate uart rx and tx wakers, add uart fifo overrun detection, and clean up uart error handling

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -918,7 +918,7 @@ impl<'a> UartRx<'a, Async> {
                     embassy_time::Timer::after_micros(buffer_config.polling_rate),
                     // detect bus errors
                     poll_fn(|cx| {
-                        self.info.waker.register(cx.waker());
+                        self.info.rx_waker.register(cx.waker());
 
                         self.info
                             .regs


### PR DESCRIPTION
This pull request refactors the UART asynchronous code to improve error handling, event notification, and interrupt management by introducing separate wakers for TX and RX operations, aligning error handling with FIFO status, and simplifying the flush and polling logic. The changes enhance the reliability and clarity of asynchronous UART operations.

**Interrupt and waker handling improvements:**

* Split the shared `waker` in the `Info` struct into separate `tx_waker` and `rx_waker` fields, and updated all related trait and macro implementations to use the new wakers for transmit and receive paths. This enables more precise event notification and avoids spurious wake-ups. [[1]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L1095-R1054) [[2]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L1105-R1065) [[3]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L1157-R1131)
* Updated the UART interrupt handler to wake the appropriate waker (`tx_waker` or `rx_waker`) based on the specific interrupt (TX idle, framing/parity/noise errors, FIFO TX/RX errors), improving separation of concerns and correctness in asynchronous event handling.

**Error handling and polling logic:**

* Changed error detection during TX and RX to rely on FIFO interrupt status (`fifointstat`) for overrun errors, and updated the error mapping to report `Error::Overrun` on FIFO TX/RX errors, making error reporting more accurate and hardware-aligned. [[1]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L581-R590) [[2]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L712-R683) [[3]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L734-R703)
* Simplified the `flush` method for TX by removing the generic `wait_on` helper and implementing the polling logic inline, directly checking for TX idle or FIFO TX error, and registering the appropriate waker.

**Register and interrupt enable/clear logic:**

* Updated how interrupt enables and clears are written, especially for FIFO error interrupts, to ensure correct hardware behavior and proper wake-up of futures waiting on UART events. [[1]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L581-R590) [[2]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L712-R683) [[3]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L734-R703) [[4]](diffhunk://#diff-2bd60f29989e7f927a4f3f4325d2ec2254df11c50d040d772fbeb67ce3abf008L1118-R1100)Testing:


Testing done:

- Ran uart-async.rs for over 24 hours, no issues.