### PR TITLE
Implement embedded-mcu Watchdog trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "embedded-mcu-hal"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#4dadf27b212ce91d884e9a33b3c2725d5d0511fb"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 dependencies = [
  "defmt",
  "num_enum",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#4dadf27b212ce91d884e9a33b3c2725d5d0511fb"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 
 [[package]]
 name = "strsim"

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "embedded-mcu-hal"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#4dadf27b212ce91d884e9a33b3c2725d5d0511fb"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 dependencies = [
  "defmt",
  "num_enum",
@@ -795,7 +795,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#4dadf27b212ce91d884e9a33b3c2725d5d0511fb"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 
 [[package]]
 name = "strsim"

--- a/examples/rt685s-evk-performance-tracing/Cargo.lock
+++ b/examples/rt685s-evk-performance-tracing/Cargo.lock
@@ -495,9 +495,10 @@ dependencies = [
 [[package]]
 name = "embedded-mcu-hal"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 dependencies = [
  "defmt",
+ "num_enum",
 ]
 
 [[package]]
@@ -772,6 +773,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "panic-probe"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +974,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#146fda33807af6aeabcade513914da95c926fbc9"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 
 [[package]]
 name = "strsim"

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "embedded-mcu-hal"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#4dadf27b212ce91d884e9a33b3c2725d5d0511fb"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 dependencies = [
  "chrono",
  "defmt",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "storage_bus"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#4dadf27b212ce91d884e9a33b3c2725d5d0511fb"
+source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
 
 [[package]]
 name = "strsim"

--- a/examples/rt685s-evk/src/bin/wwdt.rs
+++ b/examples/rt685s-evk/src/bin/wwdt.rs
@@ -14,7 +14,7 @@ use panic_probe as _;
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_imxrt::init(Default::default());
-    let mut wwdt = WindowedWatchdog::new(p.WDT0, 1_000_000);
+    let mut wwdt = WindowedWatchdog::new(p.WDT0, 2_000_000);
     wwdt.clear_timeout_flag();
     wwdt.enable_reset().lock().set_warning_threshold(4_096);
 

--- a/src/wwdt.rs
+++ b/src/wwdt.rs
@@ -108,7 +108,7 @@ const fn counter_to_time(counter: u32) -> u32 {
 
 /// Initializes low-power oscillator.
 fn init_lposc() {
-    // Enable low power oscillator
+    // Enable low power oscillator. This is safe to call multiple times - if it's already enabled, this is a no-op.
     let sysctl0 = unsafe { &*crate::pac::Sysctl0::ptr() };
     sysctl0.pdruncfg0_clr().write(|w| w.lposc_pd().set_bit());
 
@@ -212,6 +212,14 @@ impl<'d> WindowedWatchdog<'d> {
                 self.info.regs.feed().write(|w| unsafe { w.feed().bits(*byte) });
             });
         });
+    }
+}
+
+impl embedded_mcu_hal::watchdog::Watchdog for WindowedWatchdog<'_> {
+    type Error = core::convert::Infallible;
+    fn feed(&mut self) -> Result<(), Self::Error> {
+        Self::feed(self);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This implements the Watchdog trait defined in embedded-mcu. Additionally, fixes a bug in the wwdt example that could cause the watchdog to not be fed quickly enough, causing an early reset.