### PR TITLE
Update formatting to agree with nightly cargo fmt

### DIFF
--- a/examples/rt633/src/bin/espi.rs
+++ b/examples/rt633/src/bin/espi.rs
@@ -4,6 +4,7 @@
 use core::slice;
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::bind_interrupts;
 use embassy_imxrt::espi::{
@@ -11,7 +12,8 @@ use embassy_imxrt::espi::{
     PortConfig,
 };
 use embassy_imxrt::peripherals::ESPI;
-use {defmt_rtt as _, panic_probe as _, rt633_examples as _};
+use panic_probe as _;
+use rt633_examples as _;
 
 bind_interrupts!(struct Irqs {
     ESPI => InterruptHandler<ESPI>;

--- a/examples/rt633/src/bin/flexspi-nor-flash.rs
+++ b/examples/rt633/src/bin/flexspi-nor-flash.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::flexspi::nor_flash::FlexSpiNorFlash;
 use embassy_imxrt::gpio;
 use embassy_time::Timer;
-use {defmt_rtt as _, panic_probe as _, rt633_examples as _};
+use panic_probe as _;
+use rt633_examples as _;
 
 /* This example demonstrates usage of the FlexSPI NOR flash driver to read, erase, and program.
   This is for the lower level flash operations that is not safe. Application should use the

--- a/examples/rt633/src/lib.rs
+++ b/examples/rt633/src/lib.rs
@@ -1,11 +1,12 @@
 #![no_std]
 
+use defmt_rtt as _;
 use mimxrt600_fcb::FlexSpiLutOpcode::{CMD_SDR, RADDR_SDR, READ_SDR, STOP, WRITE_SDR};
 use mimxrt600_fcb::FlexSpiNumPads::Single;
 use mimxrt600_fcb::{
     ControllerMiscOption, FlexSPIFlashConfigurationBlock, SFlashPadType, SerialClkFreq, SerialNORType, flexspi_lut_seq,
 };
-use {defmt_rtt as _, panic_probe as _};
+use panic_probe as _;
 
 // auto-generated version information from Cargo.toml
 include!(concat!(env!("OUT_DIR"), "/biv.rs"));

--- a/examples/rt685s-evk/src/bin/adc.rs
+++ b/examples/rt685s-evk/src/bin/adc.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::adc::{Adc, Average, ChannelConfig, Config, InterruptHandler};
 use embassy_imxrt::{bind_interrupts, peripherals};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     ADC0 => InterruptHandler<peripherals::ADC0>;

--- a/examples/rt685s-evk/src/bin/benchmarking-gpio.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-gpio.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
+++ b/examples/rt685s-evk/src/bin/benchmarking-system-peripheral.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/button.rs
+++ b/examples/rt685s-evk/src/bin/button.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_futures::select::{Either, select};
 use embassy_imxrt::gpio;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/clocks-blinky.rs
+++ b/examples/rt685s-evk/src/bin/clocks-blinky.rs
@@ -2,11 +2,14 @@
 #![no_std]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
+use embassy_imxrt as _;
 use embassy_imxrt::iopctl::IopctlPin;
 use embassy_imxrt::{clocks, gpio};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/crc.rs
+++ b/examples/rt685s-evk/src/bin/crc.rs
@@ -1,9 +1,11 @@
 #![no_std]
 #![no_main]
 
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::crc::{Config, Crc, Polynomial};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/ctimer-pwm-0-100.rs
+++ b/examples/rt685s-evk/src/bin/ctimer-pwm-0-100.rs
@@ -2,12 +2,14 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_imxrt::pwm::{CentiPercent, MicroSeconds, Pwm};
 use embassy_imxrt::timer::{CTimerPwm, CTimerPwmPeriodChannel};
+use embassy_imxrt_examples as _;
 use embassy_time::{Duration, with_timeout};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/dma-mem.rs
+++ b/examples/rt685s-evk/src/bin/dma-mem.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::Peri;
 use embassy_imxrt::dma::Dma;
 use embassy_imxrt::dma::transfer::{Priority, Transfer, TransferOptions, Width};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 const TEST_LEN: usize = 16;
 

--- a/examples/rt685s-evk/src/bin/flexspi-embedded-storage.rs
+++ b/examples/rt685s-evk/src/bin/flexspi-embedded-storage.rs
@@ -1,11 +1,12 @@
 #![no_std]
 #![no_main]
 
+use defmt_rtt as _;
 use embassy_imxrt::flexspi::nor_flash::FlexSpiNorFlash;
 use embassy_imxrt::gpio;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use futures::FutureExt as _;
-use {defmt_rtt as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {

--- a/examples/rt685s-evk/src/bin/flexspi-nor-flash.rs
+++ b/examples/rt685s-evk/src/bin/flexspi-nor-flash.rs
@@ -1,10 +1,11 @@
 #![no_std]
 #![no_main]
 
+use defmt_rtt as _;
 use embassy_imxrt::flexspi::nor_flash::FlexSpiNorFlash;
 use embassy_imxrt::gpio;
 use futures::FutureExt as _;
-use {defmt_rtt as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: embassy_executor::Spawner) {

--- a/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
+++ b/examples/rt685s-evk/src/bin/flexspi-storage-service.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::flexspi::nor_storage_bus::{
     AhbConfig, FlexSpiFlashPort, FlexSpiFlashPortDeviceInstance, FlexspiAhbBufferConfig, FlexspiConfig,
@@ -17,11 +18,11 @@ use embassy_time::Timer;
 use embedded_storage::nor_flash::{
     ErrorType, NorFlash as BlockingNorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash as BlockingReadNorFlash,
 };
+use panic_probe as _;
 use storage_bus::nor::{
     BlockingNorStorageBusDriver, NorStorageBusWidth, NorStorageCmd, NorStorageCmdMode, NorStorageCmdType,
     NorStorageDummyCycles,
 };
-use {defmt_rtt as _, panic_probe as _};
 
 static ADDR: u32 = 0x3FD0000;
 

--- a/examples/rt685s-evk/src/bin/gpio-async-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-async-input.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::debug;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
+use embassy_imxrt_examples as _;
 use embassy_time::{Duration, Ticker};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::task]
 async fn monitor_task(mut monitor: gpio::Input<'static>) {

--- a/examples/rt685s-evk/src/bin/gpio-blinky.rs
+++ b/examples/rt685s-evk/src/bin/gpio-blinky.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-flex.rs
+++ b/examples/rt685s-evk/src/bin/gpio-flex.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::{assert, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_imxrt::gpio::SenseDisabled;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/gpio-input.rs
+++ b/examples/rt685s-evk/src/bin/gpio-input.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/hello-world.rs
+++ b/examples/rt685s-evk/src/bin/hello-world.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async-10bit.rs
@@ -2,13 +2,15 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::master::I2cMaster;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
+use embassy_imxrt_examples as _;
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 const ADDR: u16 = 0x0123;
 const MASTER_BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-loopback-async.rs
@@ -2,13 +2,15 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::master::{DutyCycle, I2cMaster};
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
+use embassy_imxrt_examples as _;
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 const ADDR: u8 = 0x20;
 const MASTER_BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-master-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-async.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::{bind_interrupts, i2c, peripherals};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 const NACK_ADDR: u8 = 0x07;
 

--- a/examples/rt685s-evk/src/bin/i2c-master-drop.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master-drop.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::{bind_interrupts, i2c, peripherals};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 const ACC_ADDR: u8 = 0x1E;
 const ACC_ID_REG: u8 = 0x0D;

--- a/examples/rt685s-evk/src/bin/i2c-master.rs
+++ b/examples/rt685s-evk/src/bin/i2c-master.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::{error, info};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
 use embedded_hal_1::i2c::I2c;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 const ACC_ADDR: u8 = 0x1E;
 

--- a/examples/rt685s-evk/src/bin/i2c-slave-async.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave-async.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
 use embassy_imxrt::i2c::{self, Async};
 use embassy_imxrt::{bind_interrupts, peripherals};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
 const BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/i2c-slave.rs
+++ b/examples/rt685s-evk/src/bin/i2c-slave.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::i2c::Blocking;
 use embassy_imxrt::i2c::slave::{Address, Command, I2cSlave, Response};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 const SLAVE_ADDR: Option<Address> = Address::new(0x20);
 const BUFLEN: usize = 8;

--- a/examples/rt685s-evk/src/bin/keyboard.rs
+++ b/examples/rt685s-evk/src/bin/keyboard.rs
@@ -2,17 +2,19 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::clocks::delay_loop_clocks;
 use embassy_imxrt::gpio;
 use embassy_imxrt::gpio::{Input, Level, Output};
 use embassy_imxrt::iopctl::{DriveMode, DriveStrength, Inverter, Pull, SlewRate};
+use embassy_imxrt_examples as _;
 use embassy_time::{Duration, Timer};
 use keyberon::debounce::Debouncer;
 use keyberon::key_code::KbHidReport;
 use keyberon::layout::Layout;
 use keyberon::matrix::Matrix;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 const COLS: usize = 4;
 const ROWS: usize = 4;

--- a/examples/rt685s-evk/src/bin/pwm.rs
+++ b/examples/rt685s-evk/src/bin/pwm.rs
@@ -2,12 +2,14 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::pac;
 use embassy_imxrt::pwm::{CentiPercent, Channel, MicroSeconds, SCTClockSource, SCTPwm};
 use embassy_imxrt::timer::{CTimerPwm, CTimerPwmPeriodChannel};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 // TODO: connect with GPIO port when that is ready
 fn setup_gpio() {

--- a/examples/rt685s-evk/src/bin/rng.rs
+++ b/examples/rt685s-evk/src/bin/rng.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::rng::Rng;
 use embassy_imxrt::{bind_interrupts, peripherals, rng};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 use rand::TryRngCore;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;

--- a/examples/rt685s-evk/src/bin/rtc-alarm.rs
+++ b/examples/rt685s-evk/src/bin/rtc-alarm.rs
@@ -4,11 +4,13 @@
 use core::task::Poll;
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::rtc::{Rtc, RtcDatetimeClock};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
 use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError, Month, UncheckedDatetime};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 /// RTC alarm struct to await the time alarm wakeup location
 /// This should be implemented by the user to handle RTC peripheral synchronization

--- a/examples/rt685s-evk/src/bin/rtc-nvram.rs
+++ b/examples/rt685s-evk/src/bin/rtc-nvram.rs
@@ -4,13 +4,15 @@
 use core::cell::RefCell;
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_imxrt::rtc::RtcNvramStorage;
+use embassy_imxrt_examples as _;
 use embassy_sync::blocking_mutex::{CriticalSectionMutex, Mutex};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::{Duration, Timer};
 use embedded_mcu_hal::{Nvram, NvramStorage};
+use panic_probe as _;
 use static_cell::StaticCell;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
 
 // Tasks demonstrating a way to share an NVRAM storage cell between multiple tasks
 #[embassy_executor::task]

--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::rtc::Rtc;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
 use embedded_mcu_hal::time::{Datetime, DatetimeClock, Month, UncheckedDatetime};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/sha256-async.rs
+++ b/examples/rt685s-evk/src/bin/sha256-async.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::{info, trace};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{self, Hashcrypt, hasher};
 use embassy_imxrt::{bind_interrupts, peripherals};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     HASHCRYPT => hashcrypt::InterruptHandler<peripherals::HASHCRYPT>;

--- a/examples/rt685s-evk/src/bin/sha256.rs
+++ b/examples/rt685s-evk/src/bin/sha256.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use defmt::{info, trace};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::hashcrypt::{Hashcrypt, hasher};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/spi-async.rs
+++ b/examples/rt685s-evk/src/bin/spi-async.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::bind_interrupts;
 use embassy_imxrt::peripherals::FLEXCOMM5;
 use embassy_imxrt::spi::{InterruptHandler, Spi};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     FLEXCOMM5 => InterruptHandler<FLEXCOMM5>;

--- a/examples/rt685s-evk/src/bin/spi-loopback.rs
+++ b/examples/rt685s-evk/src/bin/spi-loopback.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::spi::Spi;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/spi.rs
+++ b/examples/rt685s-evk/src/bin/spi.rs
@@ -2,13 +2,15 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::gpio;
 use embassy_imxrt::spi::Spi;
+use embassy_imxrt_examples as _;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use is31fl3743b_driver::{CSy, Is31fl3743b, SWx};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/time-driver-blinky.rs
+++ b/examples/rt685s-evk/src/bin/time-driver-blinky.rs
@@ -2,10 +2,13 @@
 #![no_std]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
+use embassy_imxrt as _;
 use embassy_imxrt::gpio;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {

--- a/examples/rt685s-evk/src/bin/timer.rs
+++ b/examples/rt685s-evk/src/bin/timer.rs
@@ -2,12 +2,14 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::clocks::ClockConfig;
 use embassy_imxrt::timer::{CaptureChEdge, CaptureTimer, CountingTimer};
 use embassy_imxrt::{bind_interrupts, peripherals, timer};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     CTIMER0 => timer::InterruptHandler<peripherals::CTIMER0_COUNT_CHANNEL0>;

--- a/examples/rt685s-evk/src/bin/uart-async-hw-flow-control.rs
+++ b/examples/rt685s-evk/src/bin/uart-async-hw-flow-control.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Async, Uart};
 use embassy_imxrt::{bind_interrupts, peripherals, uart};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     FLEXCOMM2 => uart::InterruptHandler<peripherals::FLEXCOMM2>;

--- a/examples/rt685s-evk/src/bin/uart-async-with-buffer.rs
+++ b/examples/rt685s-evk/src/bin/uart-async-with-buffer.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Async, Uart, UartRx};
 use embassy_imxrt::{bind_interrupts, pac, peripherals, uart};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 const BUFLEN: usize = 512;
 const POLLING_RATE_US: u64 = 1000;

--- a/examples/rt685s-evk/src/bin/uart-async-with-rtscts-buffer.rs
+++ b/examples/rt685s-evk/src/bin/uart-async-with-rtscts-buffer.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Async, Uart};
 use embassy_imxrt::{bind_interrupts, peripherals, uart};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     FLEXCOMM2 => uart::InterruptHandler<peripherals::FLEXCOMM2>;

--- a/examples/rt685s-evk/src/bin/uart-async.rs
+++ b/examples/rt685s-evk/src/bin/uart-async.rs
@@ -2,11 +2,13 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Async, Uart};
 use embassy_imxrt::{bind_interrupts, peripherals, uart};
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 bind_interrupts!(struct Irqs {
     FLEXCOMM2 => uart::InterruptHandler<peripherals::FLEXCOMM2>;

--- a/examples/rt685s-evk/src/bin/uart.rs
+++ b/examples/rt685s-evk/src/bin/uart.rs
@@ -2,9 +2,11 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::uart::{Uart, UartTx};
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use embassy_imxrt_examples as _;
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/uuid.rs
+++ b/examples/rt685s-evk/src/bin/uuid.rs
@@ -2,10 +2,12 @@
 #![no_main]
 
 use defmt::info;
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::uuid::Uuid;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/rt685s-evk/src/bin/wwdt.rs
+++ b/examples/rt685s-evk/src/bin/wwdt.rs
@@ -3,11 +3,13 @@
 
 use cortex_m::peripheral::NVIC;
 use defmt::{info, warn};
+use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_imxrt::pac::{Interrupt, interrupt};
 use embassy_imxrt::wwdt::WindowedWatchdog;
+use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use {defmt_rtt as _, embassy_imxrt_examples as _, panic_probe as _};
+use panic_probe as _;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {


### PR DESCRIPTION
It looks like there were some changes to the format imposed by `cargo fmt` in the nightly builds, which are checked as part of our CI pipelines.
Update formatting to align with the nightly formatting rules to unblock our CI pipelines.