### PR TITLE
Upgrade embedded-mcu-hal from git to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,8 +467,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-nb = { version = "1.0" }
 
-embedded-mcu-hal = { git = "https://github.com/OpenDevicePartnership/embedded-mcu", default-features = false }
+embedded-mcu-hal = { version = "0.2.0", default-features = false }
 mimxrt600-fcb = "0.2.0"
 document-features = "0.2.7"
 paste = "1.0"

--- a/examples/rt633/Cargo.lock
+++ b/examples/rt633/Cargo.lock
@@ -457,8 +457,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt",
  "num_enum",

--- a/examples/rt685s-evk-performance-tracing/Cargo.lock
+++ b/examples/rt685s-evk-performance-tracing/Cargo.lock
@@ -530,8 +530,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "defmt",
  "num_enum",

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -541,8 +541,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-mcu#6956ebdaf9d3725959dae2c57c2ab6baefae9330"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02b992c2b871b7fc616e4539258d92ea8b085e2f09cc0ad2862aa4d0e185ad1"
 dependencies = [
  "chrono",
  "defmt",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -51,7 +51,7 @@ embedded-storage-async = { version = "0.4.1" }
 is31fl3743b-driver = { version = "0.1.1", features = [ "is_blocking" ]}
 mimxrt600-fcb = "0.2.2"
 
-embedded-mcu-hal = { git = "https://github.com/OpenDevicePartnership/embedded-mcu", features = [
+embedded-mcu-hal = { version = "0.2.0", features = [
     "chrono"
 ] }
 

--- a/examples/rt685s-evk/src/bin/rtc-alarm.rs
+++ b/examples/rt685s-evk/src/bin/rtc-alarm.rs
@@ -9,7 +9,7 @@ use embassy_executor::Spawner;
 use embassy_imxrt::rtc::{Rtc, RtcDatetimeClock};
 use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError, Month, UncheckedDatetime};
+use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError, DatetimeFields, Month};
 use panic_probe as _;
 
 /// RTC alarm struct to await the time alarm wakeup location
@@ -22,9 +22,9 @@ struct RtcAlarm<'r> {
 impl<'r> Future for RtcAlarm<'r> {
     type Output = Result<(), DatetimeClockError>;
     fn poll(self: core::pin::Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
-        match self.rtc.get_current_datetime() {
+        match self.rtc.now() {
             Ok(now) => {
-                if self.expires_at <= now.to_unix_time_seconds() {
+                if self.expires_at <= now.unix_timestamp() {
                     Poll::Ready(Ok(()))
                 } else {
                     info!("Alarm pending at time {}, expires at {}", now, self.expires_at);
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
     let (dt_clock, _rtc_nvram) = r.split();
 
     // Initialize the system RTC
-    let datetime = Datetime::new(UncheckedDatetime {
+    let datetime = Datetime::new(DatetimeFields {
         year: 2026,
         month: Month::January,
         day: 12,
@@ -56,21 +56,18 @@ async fn main(_spawner: Spawner) {
         ..Default::default()
     })
     .unwrap();
-    let ret = dt_clock.set_current_datetime(&datetime);
+    let ret = dt_clock.set(datetime);
     info!("RTC set time: {:?}", datetime);
     assert!(ret.is_ok());
 
     // Show RTC functioning: Display current time before setting alarm
-    let current_time = dt_clock.get_current_datetime().unwrap();
+    let current_time = dt_clock.now().unwrap();
     info!("Current time before alarm: {:?}", current_time);
 
     info!("Waiting 5 seconds...");
     Timer::after_secs(5).await; // This timer uses the OsTimer peripheral
 
-    info!(
-        "Current time after waiting: {:?}",
-        dt_clock.get_current_datetime().unwrap()
-    );
+    info!("Current time after waiting: {:?}", dt_clock.now().unwrap());
 
     // Set an RTC alarm to trigger after ALARM_SECONDS
     info!("Setting alarm to trigger in {} seconds...", ALARM_SECONDS);
@@ -86,7 +83,7 @@ async fn main(_spawner: Spawner) {
     alarm.await.expect("Alarm failed");
 
     // Display time after alarm triggered
-    let wake_time = dt_clock.get_current_datetime().unwrap();
+    let wake_time = dt_clock.now().unwrap();
     info!("Alarm triggered! Wake time: {:?}", wake_time);
 
     // Clear the alarm

--- a/examples/rt685s-evk/src/bin/rtc-nvram.rs
+++ b/examples/rt685s-evk/src/bin/rtc-nvram.rs
@@ -10,7 +10,7 @@ use embassy_imxrt_examples as _;
 use embassy_sync::blocking_mutex::{CriticalSectionMutex, Mutex};
 use embassy_sync::once_lock::OnceLock;
 use embassy_time::{Duration, Timer};
-use embedded_mcu_hal::{Nvram, NvramStorage};
+use embedded_mcu_hal::nvram::{Nvram, NvramStorage};
 use panic_probe as _;
 use static_cell::StaticCell;
 

--- a/examples/rt685s-evk/src/bin/rtc-time.rs
+++ b/examples/rt685s-evk/src/bin/rtc-time.rs
@@ -7,7 +7,7 @@ use embassy_executor::Spawner;
 use embassy_imxrt::rtc::Rtc;
 use embassy_imxrt_examples as _;
 use embassy_time::Timer;
-use embedded_mcu_hal::time::{Datetime, DatetimeClock, Month, UncheckedDatetime};
+use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeFields, Month};
 use panic_probe as _;
 
 #[embassy_executor::main]
@@ -20,7 +20,7 @@ async fn main(_spawner: Spawner) {
 
     // Datetime clock example
     {
-        let datetime = Datetime::new(UncheckedDatetime {
+        let datetime = Datetime::new(DatetimeFields {
             year: 2024,
             month: Month::December,
             day: 4,
@@ -29,14 +29,14 @@ async fn main(_spawner: Spawner) {
         })
         .unwrap();
 
-        let ret = dt_clock.set_current_datetime(&datetime);
+        let ret = dt_clock.set(datetime);
         info!("RTC set time: {:?}", datetime);
         assert!(ret.is_ok());
 
         info!("Wait for 5 seconds");
         Timer::after_millis(DEMO_DELAY_MS).await;
 
-        let result = dt_clock.get_current_datetime();
+        let result = dt_clock.now();
         assert!(result.is_ok());
         info!("RTC get time: {:?}", result.unwrap());
     }
@@ -54,14 +54,14 @@ async fn main(_spawner: Spawner) {
 
         assert!(chrono::NaiveDateTime::from(embassy_dt) == chrono_dt);
 
-        let ret = dt_clock.set_current_datetime(&embassy_dt);
+        let ret = dt_clock.set(embassy_dt);
         info!("RTC set time as chrono::NaiveDateTime: {:?}", embassy_dt);
         assert!(ret.is_ok());
 
         info!("Wait for 5 seconds");
         Timer::after_millis(DEMO_DELAY_MS).await;
 
-        let result = dt_clock.get_current_datetime();
+        let result = dt_clock.now();
         assert!(result.is_ok());
         info!("RTC get time: {:?}", result.unwrap());
     }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -4,8 +4,8 @@ use core::marker::PhantomData;
 
 use embassy_hal_internal::interrupt::InterruptExt;
 use embassy_sync::waitqueue::AtomicWaker;
+use embedded_mcu_hal::nvram::{Nvram, NvramStorage};
 use embedded_mcu_hal::time::{Datetime, DatetimeClock, DatetimeClockError};
-use embedded_mcu_hal::{Nvram, NvramStorage};
 
 use crate::{Peri, interrupt, pac, peripherals};
 
@@ -227,20 +227,20 @@ impl<'r> RtcDatetimeClock<'r> {
 
 impl DatetimeClock for RtcDatetimeClock<'_> {
     /// Returns the current structured date and time.
-    fn get_current_datetime(&self) -> Result<Datetime, DatetimeClockError> {
-        Ok(Datetime::from_unix_time_seconds(self.get_datetime_in_secs()?))
+    fn now(&self) -> Result<Datetime, DatetimeClockError> {
+        Ok(Datetime::from_unix_timestamp(self.get_datetime_in_secs()?))
     }
 
     /// Sets the current structured date and time.
-    fn set_current_datetime(&mut self, datetime: &Datetime) -> Result<(), DatetimeClockError> {
-        self.set_datetime_in_secs(datetime.to_unix_time_seconds())
+    fn set(&mut self, datetime: Datetime) -> Result<(), DatetimeClockError> {
+        self.set_datetime_in_secs(datetime.unix_timestamp())
     }
 
     // TODO As currently implemented, we only return times with 1s resolution.  However, the hardware is capable of 1KHz
     //      resolution in some configurations.  In the future, we may consider adding a feature flag to enable setting
     //      timestamps with 1KHz resolution, but we don't currently have a use case for that.
     //
-    fn max_resolution_hz(&self) -> u32 {
+    fn resolution_hz(&self) -> u32 {
         1
     }
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -65,6 +65,11 @@ criteria = "safe-to-deploy"
 delta = "0.6.1 -> 0.7.0"
 notes = "Made Write::flush() required. Update to embedded-io 0.7 with core::Error. defmt 0.3->1.0. Fixed method forwardings. Removed nightly requirement (MSRV 1.81). Trusted publisher (Dirbaio from Embedded WG)."
 
+[[audits.embedded-mcu-hal]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+
 [[audits.mimxrt600-fcb]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Update the embedded-mcu-hal dependency from a git reference to the published v0.2.0 crate. Adapt all call sites to the breaking API changes introduced in the new version:

- Nvram/NvramStorage moved to embedded_mcu_hal::nvram module
- DatetimeClock trait methods renamed: get_current_datetime -> now, set_current_datetime -> set, max_resolution_hz -> resolution_hz
- Datetime constructors renamed: from_unix_time_seconds ->
  from_unix_timestamp, to_unix_time_seconds -> unix_timestamp
- UncheckedDatetime replaced with DatetimeFields